### PR TITLE
Fix protocol and accessory lifecycle bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,11 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "deep-equal": "^2.2.3",
-        "modbus-serial": "^8.0.25",
-        "throttle-debounce": "^5.0.2"
+        "modbus-serial": "^8.0.25"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/deep-equal": "^1.0.4",
         "@types/node": "^22.20.1",
-        "@types/throttle-debounce": "^5.0.2",
         "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^10.8.1",
         "homebridge": "^2.3.1",
@@ -1031,13 +1027,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/deep-equal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@types/deep-equal/-/deep-equal-1.0.4.tgz",
-      "integrity": "sha512-tqdiS4otQP4KmY0PR3u6KbZ5EWvhNdUoS/jc93UuK23C220lOZ/9TvjfxdPcKvqwwDVtmtSCrnr0p/2dirAxkA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -1068,13 +1057,6 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/throttle-debounce": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
-      "integrity": "sha512-pDzSNulqooSKvSNcksnV72nk8p7gRqN8As71Sp28nov1IgmPKWbOEIwAWvBME5pPTtaXJAvG3O4oc76HlQ4kqQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.67.0",
@@ -1509,22 +1491,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/array-buffer-byte-length": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
-      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "is-array-buffer": "^3.0.5"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1545,21 +1511,6 @@
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
-      }
-    },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/balanced-match": {
@@ -1625,53 +1576,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -1772,78 +1676,12 @@
         }
       }
     },
-    "node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/define-properties": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1868,20 +1706,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -1889,62 +1713,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-get-iterator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "has-symbols": "^1.0.3",
-        "is-arguments": "^1.1.1",
-        "is-map": "^2.0.2",
-        "is-set": "^2.0.2",
-        "is-string": "^1.0.7",
-        "isarray": "^2.0.5",
-        "stop-iteration-iterator": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
       "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/eslint": {
       "version": "10.8.1",
@@ -2254,21 +2028,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/from": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
@@ -2306,24 +2065,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/functions-have-names": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/futoin-hkdf": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.5.3.tgz",
@@ -2332,43 +2073,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -2401,18 +2105,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2427,57 +2119,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/hexy": {
@@ -2548,61 +2189,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/internal-slot": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
-      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "hasown": "^2.0.2",
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-array-buffer": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
-      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-bigint": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2613,48 +2199,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-boolean-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
-      "dependencies": {
-        "call-bind": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-date-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
-      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -2678,14 +2222,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2695,110 +2231,6 @@
       "engines": {
         "node": ">=0.12.0"
       }
-    },
-    "node_modules/is-number-object": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-set": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-shared-array-buffer": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
-      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-string": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
-      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-symbol": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dependencies": {
-        "has-symbols": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakmap": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakset": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.1.tgz",
-      "integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3271,15 +2703,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/minimatch": {
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -3455,63 +2878,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-is": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.assign": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
-      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/obug": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
@@ -3657,15 +3023,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.5.26",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
@@ -3740,26 +3097,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/regexp.prototype.flags": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
-      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-errors": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/rimraf": {
@@ -3906,38 +3243,6 @@
         }
       }
     },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-function-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3959,78 +3264,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/side-channel": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
-      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4",
-        "side-channel-list": "^1.0.1",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -4111,19 +3344,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/stop-iteration-iterator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "internal-slot": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/stream-combiner": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
@@ -4145,15 +3365,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/throttle-debounce": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
-      "integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.22"
       }
     },
     "node_modules/through": {
@@ -4589,56 +3800,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/which-boxed-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-      "dependencies": {
-        "is-bigint": "^1.0.1",
-        "is-boolean-object": "^1.1.0",
-        "is-number-object": "^1.0.4",
-        "is-string": "^1.0.5",
-        "is-symbol": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-collection": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-      "dependencies": {
-        "is-map": "^2.0.1",
-        "is-set": "^2.0.1",
-        "is-weakmap": "^2.0.1",
-        "is-weakset": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.22",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
-      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.9",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/why-is-node-running": {
@@ -5291,12 +4452,6 @@
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true
     },
-    "@types/deep-equal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@types/deep-equal/-/deep-equal-1.0.4.tgz",
-      "integrity": "sha512-tqdiS4otQP4KmY0PR3u6KbZ5EWvhNdUoS/jc93UuK23C220lOZ/9TvjfxdPcKvqwwDVtmtSCrnr0p/2dirAxkA==",
-      "dev": true
-    },
     "@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -5323,12 +4478,6 @@
       "requires": {
         "undici-types": "~6.21.0"
       }
-    },
-    "@types/throttle-debounce": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
-      "integrity": "sha512-pDzSNulqooSKvSNcksnV72nk8p7gRqN8As71Sp28nov1IgmPKWbOEIwAWvBME5pPTtaXJAvG3O4oc76HlQ4kqQ==",
-      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "8.67.0",
@@ -5585,15 +4734,6 @@
         "picomatch": "^2.0.4"
       }
     },
-    "array-buffer-byte-length": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
-      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
-      "requires": {
-        "call-bound": "^1.0.3",
-        "is-array-buffer": "^3.0.5"
-      }
-    },
     "assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -5609,14 +4749,6 @@
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
-      }
-    },
-    "available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "requires": {
-        "possible-typed-array-names": "^1.0.0"
       }
     },
     "balanced-match": {
@@ -5665,35 +4797,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
-    },
-    "call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "requires": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      }
-    },
-    "call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "requires": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      }
-    },
-    "call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "requires": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      }
     },
     "chai": {
       "version": "6.2.2",
@@ -5754,56 +4857,11 @@
         "ms": "^2.1.3"
       }
     },
-    "deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "requires": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      }
-    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
-    },
-    "define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "requires": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      }
-    },
-    "define-properties": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "requires": {
-        "define-data-property": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      }
     },
     "detect-libc": {
       "version": "2.1.2",
@@ -5820,61 +4878,17 @@
         "@leichtgewicht/ip-codec": "^2.0.1"
       }
     },
-    "dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "requires": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      }
-    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
     },
-    "es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
-    },
-    "es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-    },
-    "es-get-iterator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "has-symbols": "^1.0.3",
-        "is-arguments": "^1.1.1",
-        "is-map": "^2.0.2",
-        "is-set": "^2.0.2",
-        "is-string": "^1.0.7",
-        "isarray": "^2.0.5",
-        "stop-iteration-iterator": "^1.0.0"
-      }
-    },
     "es-module-lexer": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
       "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true
-    },
-    "es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "requires": {
-        "es-errors": "^1.3.0"
-      }
     },
     "eslint": {
       "version": "10.8.1",
@@ -6088,14 +5102,6 @@
       "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true
     },
-    "for-each": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "requires": {
-        "is-callable": "^1.2.7"
-      }
-    },
     "from": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
@@ -6120,47 +5126,11 @@
       "dev": true,
       "optional": true
     },
-    "function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-    },
-    "functions-have-names": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
-    },
     "futoin-hkdf": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.5.3.tgz",
       "integrity": "sha512-SewY5KdMpaoCeh7jachEWFsh1nNlaDjNHZXWqL5IGwtpEYHTgkr2+AMCgNwKWkcc0wpSYrZfR7he4WdmHFtDxQ==",
       "dev": true
-    },
-    "get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "requires": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      }
-    },
-    "get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "requires": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      }
     },
     "glob": {
       "version": "13.0.6",
@@ -6182,11 +5152,6 @@
         "is-glob": "^4.0.1"
       }
     },
-    "gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
-    },
     "graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -6198,35 +5163,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
-    },
-    "has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "requires": {
-        "es-define-property": "^1.0.0"
-      }
-    },
-    "has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
-    },
-    "has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "requires": {
-        "has-symbols": "^1.0.3"
-      }
-    },
-    "hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "requires": {
-        "function-bind": "^1.1.2"
-      }
     },
     "hexy": {
       "version": "0.4.0",
@@ -6274,40 +5210,6 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
-    "internal-slot": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
-      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
-      "requires": {
-        "es-errors": "^1.3.0",
-        "hasown": "^2.0.2",
-        "side-channel": "^1.1.0"
-      }
-    },
-    "is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "requires": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      }
-    },
-    "is-array-buffer": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
-      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
-      "requires": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      }
-    },
-    "is-bigint": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg=="
-    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -6315,28 +5217,6 @@
       "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
-      }
-    },
-    "is-boolean-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
-      "requires": {
-        "call-bind": "^1.0.0"
-      }
-    },
-    "is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
-    },
-    "is-date-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
-      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-      "requires": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
       }
     },
     "is-extglob": {
@@ -6354,77 +5234,11 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
-    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
-    },
-    "is-number-object": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
-    },
-    "is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "requires": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      }
-    },
-    "is-set": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
-    },
-    "is-shared-array-buffer": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
-      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
-      "requires": {
-        "call-bound": "^1.0.3"
-      }
-    },
-    "is-string": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
-      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
-      "requires": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      }
-    },
-    "is-symbol": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "requires": {
-        "has-symbols": "^1.0.1"
-      }
-    },
-    "is-weakmap": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
-    },
-    "is-weakset": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.1.tgz",
-      "integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw=="
-    },
-    "isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -6682,11 +5496,6 @@
       "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
       "dev": true
     },
-    "math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
-    },
     "minimatch": {
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -6795,38 +5604,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
-    "object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
-    },
-    "object-is": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "requires": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1"
-      }
-    },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
-    },
-    "object.assign": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
-      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-      "requires": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "object-keys": "^1.1.1"
-      }
-    },
     "obug": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
@@ -6920,11 +5697,6 @@
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true
     },
-    "possible-typed-array-names": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
-    },
     "postcss": {
       "version": "8.5.26",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
@@ -6967,19 +5739,6 @@
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
-      }
-    },
-    "regexp.prototype.flags": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
-      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-      "requires": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-errors": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "set-function-name": "^2.0.2"
       }
     },
     "rimraf": {
@@ -7067,30 +5826,6 @@
         }
       }
     },
-    "set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "requires": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      }
-    },
-    "set-function-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-      "requires": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.2"
-      }
-    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -7105,50 +5840,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
-    },
-    "side-channel": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
-      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
-      "requires": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4",
-        "side-channel-list": "^1.0.1",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      }
-    },
-    "side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "requires": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
-      }
-    },
-    "side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "requires": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      }
-    },
-    "side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "requires": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      }
     },
     "siginfo": {
       "version": "2.0.0",
@@ -7208,15 +5899,6 @@
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true
     },
-    "stop-iteration-iterator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-      "requires": {
-        "es-errors": "^1.3.0",
-        "internal-slot": "^1.1.0"
-      }
-    },
     "stream-combiner": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
@@ -7235,11 +5917,6 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
-    },
-    "throttle-debounce": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
-      "integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A=="
     },
     "through": {
       "version": "2.3.8",
@@ -7452,43 +6129,6 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
-      }
-    },
-    "which-boxed-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-      "requires": {
-        "is-bigint": "^1.0.1",
-        "is-boolean-object": "^1.1.0",
-        "is-number-object": "^1.0.4",
-        "is-string": "^1.0.5",
-        "is-symbol": "^1.0.3"
-      }
-    },
-    "which-collection": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-      "requires": {
-        "is-map": "^2.0.1",
-        "is-set": "^2.0.1",
-        "is-weakmap": "^2.0.1",
-        "is-weakset": "^2.0.1"
-      }
-    },
-    "which-typed-array": {
-      "version": "1.1.22",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
-      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
-      "requires": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.9",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
       }
     },
     "why-is-node-running": {

--- a/package.json
+++ b/package.json
@@ -36,15 +36,11 @@
     "supports-hap"
   ],
   "dependencies": {
-    "deep-equal": "^2.2.3",
-    "modbus-serial": "^8.0.25",
-    "throttle-debounce": "^5.0.2"
+    "modbus-serial": "^8.0.25"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/deep-equal": "^1.0.4",
     "@types/node": "^22.20.1",
-    "@types/throttle-debounce": "^5.0.2",
     "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.8.1",
     "homebridge": "^2.3.1",

--- a/src/compactPAccessory.ts
+++ b/src/compactPAccessory.ts
@@ -1,9 +1,12 @@
 import { Service, PlatformAccessory, CharacteristicEventTypes, CharacteristicValue, CharacteristicSetCallback } from 'homebridge';
-import deepEqual from 'deep-equal';
+import { isDeepStrictEqual } from 'node:util';
 
 import { DateTime, OperationMode, PauseOption, VentilationMode, WeekScheduleRecord } from './cts700Data';
-import { CTS700Modbus, NumericWriter, WriterParameterTypes } from './cts700Modbus';
-import { NilanHomebridgePlatform } from './platform';
+import { CTS700Modbus } from './cts700Modbus';
+import type { NilanHomebridgePlatform } from './platform';
+
+type WriterParameter = boolean | number | PauseOption | VentilationMode;
+type ModbusFactory = (host: string, didConnect: () => void) => CTS700Modbus;
 
 export class CompactPPlatformAccessory {
   private ventilationFanService: Service;
@@ -13,6 +16,8 @@ export class CompactPPlatformAccessory {
   private panelTemperatureSensorService: Service;
   
   private cts700Modbus: CTS700Modbus;
+  private readonly updateInterval: ReturnType<typeof setInterval>;
+  private updateInProgress = false;
 
   private processedDateTime?: DateTime;
   private processedSchedule?: WeekScheduleRecord;
@@ -20,9 +25,10 @@ export class CompactPPlatformAccessory {
   constructor(
     private readonly platform: NilanHomebridgePlatform,
     private readonly accessory: PlatformAccessory,
+    modbusFactory: ModbusFactory = (host, didConnect) => new CTS700Modbus(host, didConnect),
   ) {
 
-    this.cts700Modbus = new CTS700Modbus(this.accessory.context.device.host, () => {
+    this.cts700Modbus = modbusFactory(this.accessory.context.device.host, () => {
       this.setUpAfterConnection();
     }); 
 
@@ -37,9 +43,14 @@ export class CompactPPlatformAccessory {
     this.outsideTemperatureSensorService = this.setUpOutsideTemperatureSensor(platform, accessory);
     this.panelTemperatureSensorService = this.setUpPanelTemperatureSensor(platform, accessory);
 
-    setInterval(() => {
-      this.updateFromDevice(platform);
+    this.updateInterval = setInterval(() => {
+      void this.updateFromDevice(platform);
     }, 10000);
+  }
+
+  public shutdown(): void {
+    clearInterval(this.updateInterval);
+    this.cts700Modbus.close();
   }
 
   private async setUpAfterConnection() {
@@ -52,7 +63,7 @@ export class CompactPPlatformAccessory {
         .setCharacteristic(this.platform.Characteristic.FirmwareRevision, metadata.softwareVersion);
 
     } catch (e) {
-      this.platform.log.error('Could obtain device metadata after connection.', e instanceof Error ? e.message : '');
+      this.platform.log.error('Could not obtain device metadata after connection.', e instanceof Error ? e.message : '');
     }
   }
 
@@ -71,13 +82,13 @@ export class CompactPPlatformAccessory {
 
     ventilationFanService.getCharacteristic(c.RotationSpeed)
       .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-        this.handleWrite(CTS700Modbus.prototype.writeFanSpeed, value as number, 'Rotation speed', callback);
+        this.handleWrite(next => this.cts700Modbus.writeFanSpeed(next), value as number, 'Rotation speed', callback);
       });
 
     ventilationFanService.getCharacteristic(c.Active)
       .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-        const pauseOption = value === c.Active.INACTIVE ? PauseOption.Ventilation : PauseOption.Disabled;
-        this.handleWrite(CTS700Modbus.prototype.writePauseOption, pauseOption, 'Pause option', callback);
+        const paused = value === c.Active.INACTIVE;
+        this.handleWrite(next => this.cts700Modbus.writeVentilationPaused(next), paused, 'Ventilation pause', callback);
       });
 
     return ventilationFanService;
@@ -99,31 +110,32 @@ export class CompactPPlatformAccessory {
 
     ventilationThermostatService.getCharacteristic(c.TargetTemperature)
       .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-        this.handleWrite(CTS700Modbus.prototype.writeRoomTemperatureSetPoint, value as number, 'Room temperature', callback);
+        this.handleWrite(next => this.cts700Modbus.writeRoomTemperatureSetPoint(next), value as number, 'Room temperature', callback);
       });
     
     ventilationThermostatService.getCharacteristic(c.TargetHeatingCoolingState)
       .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-        let pauseOption: PauseOption;
+        let paused: boolean;
         let ventilationMode: VentilationMode | null = null;  
 
         if (value === c.TargetHeatingCoolingState.OFF) {
-          pauseOption = PauseOption.Ventilation;
+          paused = true;
         } else if (value === c.TargetHeatingCoolingState.HEAT) {
-          pauseOption = PauseOption.Disabled;
+          paused = false;
           ventilationMode = VentilationMode.Heating;
         } else if (value === c.TargetHeatingCoolingState.COOL) {
-          pauseOption = PauseOption.Disabled;
+          paused = false;
           ventilationMode = VentilationMode.Cooling;
         } else { //  c.TargetHeatingCoolingState.AUTO
-          pauseOption = PauseOption.Disabled;
+          paused = false;
           ventilationMode = VentilationMode.Auto;
         }
 
-        this.handleWrite(CTS700Modbus.prototype.writePauseOption, pauseOption, 'Pause option', (result) => {
+        this.handleWrite(next => this.cts700Modbus.writeVentilationPaused(next), paused, 'Ventilation pause', (result) => {
           // Only set ventilation mode if not paused and the previous operation succeeded. 
           if ((ventilationMode !== null) && (result === null)) {
-            this.handleWrite(CTS700Modbus.prototype.writeVentilationMode, ventilationMode as VentilationMode, 'Ventilation mode', callback);
+            this.handleWrite(next => this.cts700Modbus.writeVentilationMode(next), ventilationMode as VentilationMode,
+              'Ventilation mode', callback);
           } else {
             callback(result);
           }
@@ -155,13 +167,13 @@ export class CompactPPlatformAccessory {
 
     dhwThermostatService.getCharacteristic(c.TargetTemperature)
       .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-        this.handleWrite(CTS700Modbus.prototype.writeDHWSetPoint, value as number, 'DHW temperature', callback);
+        this.handleWrite(next => this.cts700Modbus.writeDHWSetPoint(next), value as number, 'DHW temperature', callback);
       });
 
     dhwThermostatService.getCharacteristic(c.TargetHeatingCoolingState)
       .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-        const pauseOption = value === c.TargetHeatingCoolingState.OFF ? PauseOption.DHW : PauseOption.Disabled;
-        this.handleWrite(CTS700Modbus.prototype.writePauseOption, pauseOption, 'Pause option', callback);
+        const paused = value === c.TargetHeatingCoolingState.OFF;
+        this.handleWrite(next => this.cts700Modbus.writeDHWPaused(next), paused, 'DHW pause', callback);
       });
 
     return dhwThermostatService;
@@ -198,6 +210,12 @@ export class CompactPPlatformAccessory {
   }
 
   private async updateFromDevice(platform: NilanHomebridgePlatform) {
+    if (this.updateInProgress) {
+      this.platform.log.debug('Skipping device update because the previous poll is still running.');
+      return;
+    }
+
+    this.updateInProgress = true;
     try {
       const readings = await this.cts700Modbus.fetchReadings();
       this.platform.log.debug('Updating with readings:', readings);
@@ -214,11 +232,11 @@ export class CompactPPlatformAccessory {
       const normalizedDateTime = readings.currentDateTime;
       normalizedDateTime.second = 0;
       const shouldSkipSchedule = this.accessory.context.device.schedule === false;
-      if (!shouldSkipSchedule && !deepEqual(normalizedDateTime, this.processedDateTime)) {
+      if (!shouldSkipSchedule && !isDeepStrictEqual(normalizedDateTime, this.processedDateTime)) {
         this.platform.log.debug('Checking week schedule.');
         const activeSchedule = await this.cts700Modbus.fetchActiveWeekProgramForDateTime(readings.currentDateTime);
 
-        if (activeSchedule && !deepEqual(activeSchedule, this.processedSchedule)) {
+        if (activeSchedule && !isDeepStrictEqual(activeSchedule, this.processedSchedule)) {
           this.platform.log.debug('Updating fan temperature, dhw temperature and fan speed to match schedule.',
             activeSchedule.temperature,
             activeSchedule.dhwTemperature,
@@ -286,23 +304,30 @@ export class CompactPPlatformAccessory {
       this.dhwThermostatService.updateCharacteristic(c.TargetTemperature, settings.dhwTemperatureSetPoint);
     } catch (e) {
       this.platform.log.error('Could not update readings and settings.', e instanceof Error ? e.message : '');
+    } finally {
+      this.updateInProgress = false;
     }
   }
 
-  private async handleWrite(writer: NumericWriter, value: WriterParameterTypes, name: string, callback: CharacteristicSetCallback): 
-    Promise<WriterParameterTypes | null> {
+  private async handleWrite<T extends WriterParameter, R extends WriterParameter>(
+    writer: (value: T) => Promise<R>,
+    value: T,
+    name: string,
+    callback: CharacteristicSetCallback,
+  ): Promise<R | null> {
       
-    this.platform.log.debug(name, 'updating to to:', value);
+    this.platform.log.debug(name, 'updating to:', value);
 
-    return writer.call(this.cts700Modbus, value)
+    return writer(value)
       .then((result) => {
         this.platform.log.debug(name, 'update ok. Wrote:', result);
         callback(null);
         return result;
       })
-      .catch((error) => {
-        this.platform.log.debug(name, 'update failed. Error:', error.message);
-        callback(error);
+      .catch((error: unknown) => {
+        const callbackError = error instanceof Error ? error : new Error(String(error));
+        this.platform.log.debug(name, 'update failed. Error:', callbackError.message);
+        callback(callbackError);
         return null;
       });
   }

--- a/src/compactPAccessory.ts
+++ b/src/compactPAccessory.ts
@@ -160,7 +160,7 @@ export class CompactPPlatformAccessory {
     });
     dhwThermostatService.updateCharacteristic(c.TemperatureDisplayUnits, c.TemperatureDisplayUnits.CELSIUS);
     dhwThermostatService.getCharacteristic(c.TargetTemperature).setProps({
-      minValue: 5,
+      minValue: 10,
       maxValue: 65,
       minStep: 1,
     });

--- a/src/cts700Data.ts
+++ b/src/cts700Data.ts
@@ -45,6 +45,8 @@ export enum Register {
 	FistWeekProgram = FirstWeekProgram,
 	// Second 14 program records of Week Program.
 	SecondWeekProgram = 643,
+	// Third 14 program records of Week Program.
+	ThirdWeekProgram = 713,
 	// The MAC address for main board device.
 	// Reg1 Hi-byte: MAC 1-st byte
 	// Reg1 Lo-byte: MAC 2-nd byte
@@ -113,7 +115,7 @@ export interface Settings {
 	fanSpeed: number;
 	// Desired room temperature in C (5-40) times 10
 	roomTemperatureSetPoint: number;
-	// Desired DHW temperature in C (10-60) times 10
+	// Desired DHW temperature in C (10-65) times 10
 	dhwTemperatureSetPoint: number;
 	// Ventilation mode indicates automatic or forced aur conditioning operation
 	ventilationMode: VentilationMode;

--- a/src/cts700Data.ts
+++ b/src/cts700Data.ts
@@ -40,7 +40,9 @@ export enum Register {
 	// Current Date-Time value.
 	CurrentTime = 4722,
 	// First 14 program records of Week Program.
-	FistWeekProgram = 573,
+	FirstWeekProgram = 573,
+	// Kept as an alias for consumers compiled against the original typo.
+	FistWeekProgram = FirstWeekProgram,
 	// Second 14 program records of Week Program.
 	SecondWeekProgram = 643,
 	// The MAC address for main board device.
@@ -170,4 +172,3 @@ export interface WeekScheduleRecord {
 	// 0 ÷ 100 (%)
 	fanSpeed: number;
 }
-

--- a/src/cts700Modbus.ts
+++ b/src/cts700Modbus.ts
@@ -1,5 +1,4 @@
 import ModbusRTU from 'modbus-serial';
-import { throttle } from 'throttle-debounce';
 import { ReadRegisterResult, WriteRegisterResult } from 'modbus-serial/ModbusRTU';
 import {
   DateTime, 
@@ -13,12 +12,11 @@ import {
   WeekScheduleRecord,
 } from './cts700Data';
 
-export declare type WriterParameterTypes = number | PauseOption | OperationMode;
-export declare type NumericWriter = (value: WriterParameterTypes) => Promise<WriterParameterTypes>;
-
 export class CTS700Modbus {
 
   private client: ModbusRTU | null = null;
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
+  private disposed = false;
 
   private networkErrors = [
     'ESOCKETTIMEDOUT',
@@ -44,12 +42,19 @@ export class CTS700Modbus {
     this.connect();
   }
 
-  private connect() {
+  private connect(): void {
+    if (this.disposed) {
+      return;
+    }
     this.client = null;
 
     const client = new ModbusRTU();
     client.connectTCP(this.host, { port: 502 })
       .then(() => {
+        if (this.disposed) {
+          client.close();
+          return;
+        }
         client.setID(1);
         client.setTimeout(5000);
         this.client = client;
@@ -60,22 +65,48 @@ export class CTS700Modbus {
       });
   }
 
-  private throttledReconnect = throttle(10000, () => {
-    if (this.client !== null && this.client.isOpen) {
-      this.client.close(() => {
-        this.connect();
-      });
-    } else {
-      this.connect();
+  private scheduleReconnect(): void {
+    if (this.disposed || this.reconnectTimer !== undefined) {
+      return;
     }
-  });
 
-  // eslint-disable-next-line
-    private checkError(e: any, forceRetry: boolean = false) {
-    if((e.message && this.networkErrors.includes(e.message))
-          || (e.errno && this.networkErrors.includes(e.errno)) 
-          || forceRetry) {
-      this.throttledReconnect();
+    const client = this.client;
+    this.client = null;
+    if (client?.isOpen) {
+      client.close();
+    }
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      this.connect();
+    }, 10000);
+  }
+
+  private checkError(error: unknown, forceRetry: boolean = false): void {
+    const networkError = typeof error === 'object' && error !== null ? error as NodeJS.ErrnoException : undefined;
+    const errorValues = [
+      networkError?.code,
+      networkError?.errno?.toString(),
+      networkError?.message,
+      typeof error === 'string' ? error : undefined,
+    ];
+    const shouldRetry = this.networkErrors.some(code => errorValues.some(value => value?.includes(code)));
+    if (forceRetry || shouldRetry) {
+      this.scheduleReconnect();
+    }
+  }
+
+  public close(): void {
+    this.disposed = true;
+    if (this.reconnectTimer !== undefined) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
+
+    const client = this.client;
+    this.client = null;
+    if (client?.isOpen) {
+      client.close();
     }
   }
 
@@ -114,10 +145,10 @@ export class CTS700Modbus {
   }
 
   async fetchActiveWeekProgramForDateTime(dateTime: DateTime): Promise<WeekScheduleRecord | null> {
-    const weekSchedule = await this.readWeekProgramRegister(Register.FistWeekProgram, 14);
+    const weekSchedule = await this.readWeekProgramRegister(Register.FirstWeekProgram, 14);
     if (weekSchedule.length === 14) {
       const secondWeekSchedule = await this.readWeekProgramRegister(Register.SecondWeekProgram, 14);
-      weekSchedule.concat(secondWeekSchedule);
+      weekSchedule.push(...secondWeekSchedule);
     }
     return this.findCurrentActiveWeekRecord(weekSchedule, dateTime);
   }
@@ -293,6 +324,14 @@ export class CTS700Modbus {
     return this.writeSingleRegister(Register.Pause, value);
   }
 
+  public async writeVentilationPaused(paused: boolean): Promise<PauseOption> {
+    return this.writePauseComponent(PauseOption.Ventilation, paused);
+  }
+
+  public async writeDHWPaused(paused: boolean): Promise<PauseOption> {
+    return this.writePauseComponent(PauseOption.DHW, paused);
+  }
+
   public async writeVentilationMode(value: VentilationMode): Promise<VentilationMode> {
     if (value < VentilationMode.Auto || value > VentilationMode.Heating) {
       throw Error('Invalid ventilation mode value.');
@@ -309,9 +348,15 @@ export class CTS700Modbus {
   }
 
   private async writeTemperatureRegister(register: Register, value: number): Promise<number> {
-    // Convert to modbus format (adjust negative values and get rid of floating point precision)
-    const modbusValue = Math.floor(value < 0 ? (value * 10) + 65535 : (value * 10));
+    const signedValue = Math.round(value * 10);
+    const modbusValue = signedValue < 0 ? signedValue + 0x10000 : signedValue;
     return this.writeSingleRegister(register, modbusValue);
+  }
+
+  private async writePauseComponent(component: PauseOption, paused: boolean): Promise<PauseOption> {
+    const current = await this.readPauseRegister(Register.Pause);
+    const updated = paused ? current | component : current & ~component;
+    return this.writePauseOption(updated as PauseOption);
   }
 
   private async writeSingleRegister(register: Register, value: number): Promise<number> {
@@ -341,39 +386,17 @@ export class CTS700Modbus {
     } else if (records.length === 1) {
       return records[0];
     }
-    // We create a fake schedule record based on the current time.
-    // After sorting we just take the preceding entry as the currently
-    // active schedule record.
-    const fakeRecord: WeekScheduleRecord = {
-      weekDay: time.weekDay,
-      hour: time.hour,
-      minute: time.minute,
-      temperature: Number.MAX_SAFE_INTEGER,
-      dhwTemperature: Number.MAX_SAFE_INTEGER,
-      flags: Number.MAX_SAFE_INTEGER,
-      fanSpeed: Number.MAX_SAFE_INTEGER,
-    };
+    const minuteOfWeek = (value: Pick<DateTime, 'weekDay' | 'hour' | 'minute'>) =>
+      ((value.weekDay - 1) * 24 * 60) + (value.hour * 60) + value.minute;
+    const currentMinute = minuteOfWeek(time);
+    const sortedRecords = [...records].sort((a, b) => minuteOfWeek(a) - minuteOfWeek(b));
 
-    records.push(fakeRecord);
-
-    records.sort(
-      (a, b) => {          
-        if (a.weekDay === b.weekDay) {
-          if (a.hour === b.hour) {
-            if (a.minute === b.minute) {
-              return a.temperature > b.temperature ? 1 : -1;
-            }
-            return a.minute > b.minute ? 1 : -1;
-          }
-          return a.hour > b.hour ? 1 : -1;
-        }
-        return a.weekDay > b.weekDay ? 1 : -1;
-      });
-      
-    const index = records.indexOf(fakeRecord);
-    if (index === 0) {
-      return records[records.length - 1];
+    for (let index = sortedRecords.length - 1; index >= 0; index--) {
+      if (minuteOfWeek(sortedRecords[index]) <= currentMinute) {
+        return sortedRecords[index];
+      }
     }
-    return records[index - 1];
+
+    return sortedRecords[sortedRecords.length - 1];
   }
 }

--- a/src/cts700Modbus.ts
+++ b/src/cts700Modbus.ts
@@ -145,10 +145,14 @@ export class CTS700Modbus {
   }
 
   async fetchActiveWeekProgramForDateTime(dateTime: DateTime): Promise<WeekScheduleRecord | null> {
-    const weekSchedule = await this.readWeekProgramRegister(Register.FirstWeekProgram, 14);
-    if (weekSchedule.length === 14) {
-      const secondWeekSchedule = await this.readWeekProgramRegister(Register.SecondWeekProgram, 14);
-      weekSchedule.push(...secondWeekSchedule);
+    const weekSchedule = Array<WeekScheduleRecord>();
+    const weekProgramRegisters = [Register.FirstWeekProgram, Register.SecondWeekProgram, Register.ThirdWeekProgram];
+    for (const register of weekProgramRegisters) {
+      const records = await this.readWeekProgramRegister(register, 14);
+      weekSchedule.push(...records);
+      if (records.length < 14) {
+        break;
+      }
     }
     return this.findCurrentActiveWeekRecord(weekSchedule, dateTime);
   }
@@ -311,7 +315,7 @@ export class CTS700Modbus {
   }
 
   public async writeDHWSetPoint(value: number): Promise<number> {
-    if (value < 5 || value > 65) {
+    if (value < 10 || value > 65) {
       throw Error('Value outside of acceptable range.');
     }
     return this.writeTemperatureRegister(Register.DHWTemperatureSetPoint, value);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,4 +1,4 @@
-import { API, DynamicPlatformPlugin, Logger, PlatformAccessory, PlatformConfig, Service, Characteristic } from 'homebridge';
+import type { API, DynamicPlatformPlugin, Logger, PlatformAccessory, PlatformConfig, Service, Characteristic } from 'homebridge';
 
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings';
 import { CompactPPlatformAccessory } from './compactPAccessory';
@@ -9,6 +9,7 @@ export class NilanHomebridgePlatform implements DynamicPlatformPlugin {
 
   // This is used to track restored cached accessories
   public readonly accessories: PlatformAccessory[] = [];
+  private readonly accessoryHandlers = new Map<string, CompactPPlatformAccessory>();
 
   constructor(
     public readonly log: Logger,
@@ -25,6 +26,11 @@ export class NilanHomebridgePlatform implements DynamicPlatformPlugin {
     this.api.on('didFinishLaunching', () => {
       this.discoverDevices();
     });
+    this.api.on('shutdown', () => {
+      for (const handler of this.accessoryHandlers.values()) {
+        handler.shutdown();
+      }
+    });
   }
 
   /**
@@ -35,6 +41,12 @@ export class NilanHomebridgePlatform implements DynamicPlatformPlugin {
     this.log.info('Loading accessory from cache:', accessory.displayName);
     // add the restored accessory to the accessories cache so we can track if it has already been registered
     this.accessories.push(accessory);
+  }
+
+  private setUpAccessory(accessory: PlatformAccessory): void {
+    if (!this.accessoryHandlers.has(accessory.UUID)) {
+      this.accessoryHandlers.set(accessory.UUID, new CompactPPlatformAccessory(this, accessory));
+    }
   }
 
   /**
@@ -48,6 +60,7 @@ export class NilanHomebridgePlatform implements DynamicPlatformPlugin {
       return;
     }
 
+    const configuredHosts = new Set<string>();
     for (const device of devices) {
       const host = device.host;
       const name = device.name;
@@ -55,6 +68,11 @@ export class NilanHomebridgePlatform implements DynamicPlatformPlugin {
         this.log.warn('Encountered a device without required attributes (name / host). Skipping it.');
         continue;
       }
+      if (configuredHosts.has(host)) {
+        this.log.warn('Encountered duplicate device host in configuration:', host, 'Skipping it.');
+        continue;
+      }
+      configuredHosts.add(host);
 
       // We're using the IP as the UUID to avoid making network requests at this point.
       // The IP is a static one. It can technically be changed in the device settings, but that's
@@ -74,7 +92,7 @@ export class NilanHomebridgePlatform implements DynamicPlatformPlugin {
 
         // create the accessory handler for the restored accessory
         // this is imported from `platformAccessory.ts`
-        new CompactPPlatformAccessory(this, existingAccessory);
+        this.setUpAccessory(existingAccessory);
           
         // update accessory cache with any changes to the accessory details and information
         this.api.updatePlatformAccessories([existingAccessory]);
@@ -87,18 +105,23 @@ export class NilanHomebridgePlatform implements DynamicPlatformPlugin {
 
         // create the accessory handler for the newly create accessory
         // this is imported from `compactPAccessory.ts`
-        new CompactPPlatformAccessory(this, accessory);
+        this.setUpAccessory(accessory);
 
         // link the accessory to your platform
         this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+        this.accessories.push(accessory);
       }
     }
 
     // Remove existing accessories that were removed from the configuration.
-    for (const existingAccessory of this.accessories) {
-      if (devices.find(device => device.host === existingAccessory.context.device.host) === undefined) {
+    for (let index = this.accessories.length - 1; index >= 0; index--) {
+      const existingAccessory = this.accessories[index];
+      if (!configuredHosts.has(existingAccessory.context.device?.host)) {
+        this.accessoryHandlers.get(existingAccessory.UUID)?.shutdown();
+        this.accessoryHandlers.delete(existingAccessory.UUID);
         this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [existingAccessory]);
         this.log.info('Removing existing accessory from cache:', existingAccessory.displayName);
+        this.accessories.splice(index, 1);
       }
     }
   }

--- a/test/compactPAccessory.test.ts
+++ b/test/compactPAccessory.test.ts
@@ -1,0 +1,218 @@
+import type { CharacteristicSetCallback, CharacteristicValue, PlatformAccessory } from 'homebridge';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OperationMode, PauseOption, VentilationMode } from '../src/cts700Data';
+import type { CTS700Modbus } from '../src/cts700Modbus';
+
+vi.mock('homebridge', () => ({
+  CharacteristicEventTypes: { SET: 'set' },
+}));
+
+import { CompactPPlatformAccessory } from '../src/compactPAccessory';
+import type { NilanHomebridgePlatform } from '../src/platform';
+
+type SetHandler = (value: CharacteristicValue, callback: CharacteristicSetCallback) => void;
+
+class FakeCharacteristic {
+  public setHandler?: SetHandler;
+
+  setProps(): this {
+    return this;
+  }
+
+  on(_event: string, handler: SetHandler): this {
+    this.setHandler = handler;
+    return this;
+  }
+}
+
+class FakeService {
+  public readonly characteristics = new Map<unknown, FakeCharacteristic>();
+  public readonly updates: Array<[unknown, unknown]> = [];
+
+  getCharacteristic(characteristic: unknown): FakeCharacteristic {
+    const existing = this.characteristics.get(characteristic);
+    if (existing) {
+      return existing;
+    }
+    const created = new FakeCharacteristic();
+    this.characteristics.set(characteristic, created);
+    return created;
+  }
+
+  setCharacteristic(characteristic: unknown, value: unknown): this {
+    this.updates.push([characteristic, value]);
+    return this;
+  }
+
+  updateCharacteristic(characteristic: unknown, value: unknown): this {
+    this.updates.push([characteristic, value]);
+    return this;
+  }
+}
+
+function createHarness(schedule = false) {
+  const Characteristic = {
+    Active: Object.assign(Symbol('Active'), { ACTIVE: 1, INACTIVE: 0 }),
+    CurrentHeatingCoolingState: Object.assign(Symbol('CurrentHeatingCoolingState'), { COOL: 2, HEAT: 1, OFF: 0 }),
+    CurrentRelativeHumidity: Symbol('CurrentRelativeHumidity'),
+    CurrentTemperature: Symbol('CurrentTemperature'),
+    FirmwareRevision: Symbol('FirmwareRevision'),
+    Manufacturer: Symbol('Manufacturer'),
+    Model: Symbol('Model'),
+    RotationSpeed: Symbol('RotationSpeed'),
+    SerialNumber: Symbol('SerialNumber'),
+    TargetHeatingCoolingState: Object.assign(Symbol('TargetHeatingCoolingState'), { AUTO: 3, COOL: 2, HEAT: 1, OFF: 0 }),
+    TargetTemperature: Symbol('TargetTemperature'),
+    TemperatureDisplayUnits: Object.assign(Symbol('TemperatureDisplayUnits'), { CELSIUS: 0 }),
+  };
+  const ServiceTypes = {
+    AccessoryInformation: Symbol('AccessoryInformation'),
+    Fanv2: Symbol('Fanv2'),
+    TemperatureSensor: Symbol('TemperatureSensor'),
+    Thermostat: Symbol('Thermostat'),
+  };
+  const informationService = new FakeService();
+  const services = new Map<string, FakeService>();
+  const accessory = {
+    addService: vi.fn((_type: unknown, _name: string, subtype: string) => {
+      const service = new FakeService();
+      services.set(subtype, service);
+      return service;
+    }),
+    context: { device: { host: '192.0.2.1', schedule } },
+    getService: vi.fn(() => informationService),
+    getServiceById: vi.fn((_type: unknown, subtype: string) => services.get(subtype)),
+  };
+  const platform = {
+    Characteristic,
+    Service: ServiceTypes,
+    log: {
+      debug: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+  const modbus = {
+    close: vi.fn(),
+    fetchActiveWeekProgramForDateTime: vi.fn(),
+    fetchMetadata: vi.fn().mockResolvedValue({ macAddress: '00:11:22:33:44:55', softwareVersion: '1.2.3' }),
+    fetchReadings: vi.fn().mockResolvedValue({
+      actualHumidity: 48,
+      currentDateTime: { second: 1, minute: 2, hour: 3, day: 4, weekDay: 5, month: 6, year: 26 },
+      dhwTankTopTemperature: 51,
+      outdoorTemperature: -5,
+      panelTemperature: 20,
+      roomTemperature: 21,
+    }),
+    fetchSettings: vi.fn().mockResolvedValue({
+      dhwTemperatureSetPoint: 50,
+      fanSpeed: 60,
+      operationMode: OperationMode.Heating,
+      paused: PauseOption.Disabled,
+      roomTemperatureSetPoint: 22,
+      ventilationMode: VentilationMode.Auto,
+    }),
+    writeDHWPaused: vi.fn().mockResolvedValue(PauseOption.Disabled),
+    writeDHWSetPoint: vi.fn().mockResolvedValue(50),
+    writeFanSpeed: vi.fn().mockResolvedValue(60),
+    writeRoomTemperatureSetPoint: vi.fn().mockResolvedValue(22),
+    writeVentilationMode: vi.fn().mockResolvedValue(VentilationMode.Auto),
+    writeVentilationPaused: vi.fn().mockResolvedValue(PauseOption.Disabled),
+  };
+  let didConnect: (() => void) | undefined;
+  const handler = new CompactPPlatformAccessory(
+    platform as unknown as NilanHomebridgePlatform,
+    accessory as unknown as PlatformAccessory,
+    (_host, callback) => {
+      didConnect = callback;
+      return modbus as unknown as CTS700Modbus;
+    },
+  );
+
+  return { accessory, Characteristic, didConnect: () => didConnect?.(), handler, informationService, modbus, platform, services };
+}
+
+async function invokeSet(service: FakeService, characteristic: unknown, value: CharacteristicValue) {
+  const callback = vi.fn();
+  service.getCharacteristic(characteristic).setHandler!(value, callback);
+  await vi.waitFor(() => expect(callback).toHaveBeenCalledWith(null));
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('CompactPPlatformAccessory', () => {
+  it('loads metadata after Modbus connects', async () => {
+    const { Characteristic, didConnect, informationService } = createHarness();
+
+    didConnect();
+    await vi.waitFor(() => expect(informationService.updates).toContainEqual([Characteristic.SerialNumber, '00:11:22:33:44:55']));
+    expect(informationService.updates).toContainEqual([Characteristic.FirmwareRevision, '1.2.3']);
+  });
+
+  it('routes HomeKit writes through component-preserving pause operations', async () => {
+    const { Characteristic, modbus, services } = createHarness();
+
+    await invokeSet(services.get('compact-p-fan')!, Characteristic.Active, Characteristic.Active.INACTIVE);
+    await invokeSet(services.get('compact-p-dhw')!, Characteristic.TargetHeatingCoolingState,
+      Characteristic.TargetHeatingCoolingState.OFF);
+    await invokeSet(services.get('compact-p-temperature')!, Characteristic.TargetHeatingCoolingState,
+      Characteristic.TargetHeatingCoolingState.HEAT);
+
+    expect(modbus.writeVentilationPaused).toHaveBeenNthCalledWith(1, true);
+    expect(modbus.writeDHWPaused).toHaveBeenCalledWith(true);
+    expect(modbus.writeVentilationPaused).toHaveBeenLastCalledWith(false);
+    expect(modbus.writeVentilationMode).toHaveBeenCalledWith(VentilationMode.Heating);
+  });
+
+  it('polls readings and settings into HomeKit services', async () => {
+    const { Characteristic, modbus, services } = createHarness();
+
+    await vi.advanceTimersByTimeAsync(10000);
+
+    expect(modbus.fetchReadings).toHaveBeenCalledOnce();
+    expect(modbus.fetchSettings).toHaveBeenCalledOnce();
+    expect(services.get('compact-p-temperature')!.updates).toContainEqual([Characteristic.CurrentTemperature, 21]);
+    expect(services.get('compact-p-fan')!.updates).toContainEqual([Characteristic.RotationSpeed, 60]);
+    expect(services.get('compact-p-dhw')!.updates).toContainEqual([Characteristic.TargetTemperature, 50]);
+  });
+
+  it('does not overlap slow polling cycles', async () => {
+    const { modbus } = createHarness();
+    let resolveReadings: ((value: unknown) => void) | undefined;
+    modbus.fetchReadings.mockImplementationOnce(() => new Promise(resolve => {
+      resolveReadings = resolve;
+    }));
+
+    await vi.advanceTimersByTimeAsync(10000);
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(modbus.fetchReadings).toHaveBeenCalledOnce();
+
+    resolveReadings!({
+      actualHumidity: 48,
+      currentDateTime: { second: 1, minute: 2, hour: 3, day: 4, weekDay: 5, month: 6, year: 26 },
+      dhwTankTopTemperature: 51,
+      outdoorTemperature: -5,
+      panelTemperature: 20,
+      roomTemperature: 21,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(modbus.fetchReadings).toHaveBeenCalledTimes(2);
+  });
+
+  it('cleans up polling and Modbus state on shutdown', async () => {
+    const { handler, modbus } = createHarness();
+
+    handler.shutdown();
+    await vi.advanceTimersByTimeAsync(20000);
+
+    expect(modbus.close).toHaveBeenCalledOnce();
+    expect(modbus.fetchReadings).not.toHaveBeenCalled();
+  });
+});

--- a/test/compactPAccessory.test.ts
+++ b/test/compactPAccessory.test.ts
@@ -15,8 +15,10 @@ type SetHandler = (value: CharacteristicValue, callback: CharacteristicSetCallba
 
 class FakeCharacteristic {
   public setHandler?: SetHandler;
+  public props?: Record<string, number>;
 
-  setProps(): this {
+  setProps(props: Record<string, number>): this {
+    this.props = props;
     return this;
   }
 
@@ -168,6 +170,15 @@ describe('CompactPPlatformAccessory', () => {
     expect(modbus.writeDHWPaused).toHaveBeenCalledWith(true);
     expect(modbus.writeVentilationPaused).toHaveBeenLastCalledWith(false);
     expect(modbus.writeVentilationMode).toHaveBeenCalledWith(VentilationMode.Heating);
+  });
+
+  it('uses the controller-supported DHW temperature range', () => {
+    const { Characteristic, services } = createHarness();
+
+    expect(services.get('compact-p-dhw')!.getCharacteristic(Characteristic.TargetTemperature).props).toMatchObject({
+      minValue: 10,
+      maxValue: 65,
+    });
   });
 
   it('polls readings and settings into HomeKit services', async () => {

--- a/test/cts700Modbus.test.ts
+++ b/test/cts700Modbus.test.ts
@@ -279,6 +279,38 @@ describe('CTS700Modbus reads', () => {
     expect(client.readHoldingRegisters).toHaveBeenCalledWith(Register.SecondWeekProgram, 70);
   });
 
+  it('reads and selects records from the third segment of a full week program', async () => {
+    const modbus = await createModbus();
+    const fullSegment = Array.from({ length: 14 }, (_, hour) => ({
+      weekDay: 1,
+      hour,
+      minute: 0,
+      temperature: 20,
+      dhwTemperature: 48,
+      flags: 0,
+      fanSpeed: 40,
+    }));
+    client.readHoldingRegisters.mockImplementation(async (address: number) => {
+      if (address === Register.ThirdWeekProgram) {
+        return scheduleResult([
+          { weekDay: 7, hour: 23, minute: 0, temperature: 22, dhwTemperature: 52, flags: 0, fanSpeed: 70 },
+        ]);
+      }
+      return scheduleResult(fullSegment);
+    });
+
+    await expect(modbus.fetchActiveWeekProgramForDateTime({
+      second: 0,
+      minute: 30,
+      hour: 23,
+      day: 1,
+      weekDay: 7,
+      month: 1,
+      year: 26,
+    })).resolves.toMatchObject({ weekDay: 7, hour: 23, fanSpeed: 70 });
+    expect(client.readHoldingRegisters).toHaveBeenCalledWith(Register.ThirdWeekProgram, 70);
+  });
+
   it('rejects reads while disconnected', async () => {
     const modbus = await createModbus();
     (modbus as unknown as { client: null }).client = null;
@@ -309,7 +341,8 @@ describe('CTS700Modbus writes', () => {
   it.each([
     ['fan speed', () => createModbus().then((modbus) => modbus.writeFanSpeed(101))],
     ['room temperature', () => createModbus().then((modbus) => modbus.writeRoomTemperatureSetPoint(4.5))],
-    ['DHW temperature', () => createModbus().then((modbus) => modbus.writeDHWSetPoint(66))],
+    ['low DHW temperature', () => createModbus().then((modbus) => modbus.writeDHWSetPoint(9.5))],
+    ['high DHW temperature', () => createModbus().then((modbus) => modbus.writeDHWSetPoint(66))],
     ['pause option', () => createModbus().then((modbus) => modbus.writePauseOption(99 as PauseOption))],
     ['ventilation mode', () => createModbus().then((modbus) => modbus.writeVentilationMode(99 as VentilationMode))],
   ])('rejects an invalid %s', async (_name, operation) => {

--- a/test/cts700Modbus.test.ts
+++ b/test/cts700Modbus.test.ts
@@ -1,11 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { OperationMode, PauseOption, Register, VentilationMode } from '../src/cts700Data';
 import { CTS700Modbus } from '../src/cts700Modbus';
 
 const { MockModbusRTU, client } = vi.hoisted(() => {
   const client = {
-    close: vi.fn((callback: () => void) => callback()),
+    close: vi.fn((callback?: () => void) => callback?.()),
     connectTCP: vi.fn<() => Promise<void>>(),
     isOpen: true,
     readHoldingRegisters: vi.fn(),
@@ -69,6 +69,10 @@ beforeEach(() => {
   client.writeRegister.mockImplementation(async (address: number, value: number) => ({ address, value }));
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe('CTS700Modbus connection', () => {
   it('connects with the CTS700 TCP defaults', async () => {
     await createModbus();
@@ -77,6 +81,34 @@ describe('CTS700Modbus connection', () => {
     expect(client.connectTCP).toHaveBeenCalledWith('192.0.2.1', { port: 502 });
     expect(client.setID).toHaveBeenCalledWith(1);
     expect(client.setTimeout).toHaveBeenCalledWith(5000);
+  });
+
+  it('reconnects after network errors and recognizes the Node error code', async () => {
+    const modbus = await createModbus();
+    vi.useFakeTimers();
+    const error = Object.assign(new Error('socket failure'), { code: 'ECONNRESET' });
+    client.readHoldingRegisters.mockRejectedValue(error);
+
+    await expect(modbus.fetchReadings()).rejects.toBe(error);
+    expect(client.close).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(client.connectTCP).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it('cancels pending reconnects when closed', async () => {
+    const modbus = await createModbus();
+    vi.useFakeTimers();
+    const error = Object.assign(new Error('socket failure'), { code: 'ETIMEDOUT' });
+    client.readHoldingRegisters.mockRejectedValue(error);
+
+    await expect(modbus.fetchReadings()).rejects.toBe(error);
+    modbus.close();
+    await vi.advanceTimersByTimeAsync(10000);
+
+    expect(client.connectTCP).toHaveBeenCalledOnce();
+    vi.useRealTimers();
   });
 });
 
@@ -215,6 +247,38 @@ describe('CTS700Modbus reads', () => {
     })).resolves.toBeNull();
   });
 
+  it('reads and selects records from the second half of a full week program', async () => {
+    const modbus = await createModbus();
+    const firstHalf = Array.from({ length: 14 }, (_, hour) => ({
+      weekDay: 1,
+      hour,
+      minute: 0,
+      temperature: 20,
+      dhwTemperature: 48,
+      flags: 0,
+      fanSpeed: 40,
+    }));
+    client.readHoldingRegisters.mockImplementation(async (address: number) => {
+      if (address === Register.FirstWeekProgram) {
+        return scheduleResult(firstHalf);
+      }
+      return scheduleResult([
+        { weekDay: 7, hour: 23, minute: 0, temperature: 22, dhwTemperature: 52, flags: 0, fanSpeed: 70 },
+      ]);
+    });
+
+    await expect(modbus.fetchActiveWeekProgramForDateTime({
+      second: 0,
+      minute: 30,
+      hour: 23,
+      day: 1,
+      weekDay: 7,
+      month: 1,
+      year: 26,
+    })).resolves.toMatchObject({ weekDay: 7, hour: 23, fanSpeed: 70 });
+    expect(client.readHoldingRegisters).toHaveBeenCalledWith(Register.SecondWeekProgram, 70);
+  });
+
   it('rejects reads while disconnected', async () => {
     const modbus = await createModbus();
     (modbus as unknown as { client: null }).client = null;
@@ -257,5 +321,29 @@ describe('CTS700Modbus writes', () => {
     client.writeRegister.mockResolvedValue({ address: Register.FanSpeed, value: 20 });
 
     await expect(modbus.writeFanSpeed(50)).rejects.toThrow('Setting value failed.');
+  });
+
+  it('preserves the DHW pause bit when changing ventilation pause', async () => {
+    const modbus = await createModbus();
+    client.readHoldingRegisters.mockResolvedValueOnce(registerResult([PauseOption.DHW]));
+
+    await expect(modbus.writeVentilationPaused(true)).resolves.toBe(PauseOption.All);
+    expect(client.writeRegister).toHaveBeenLastCalledWith(Register.Pause, PauseOption.All);
+
+    client.readHoldingRegisters.mockResolvedValueOnce(registerResult([PauseOption.All]));
+    await expect(modbus.writeVentilationPaused(false)).resolves.toBe(PauseOption.DHW);
+    expect(client.writeRegister).toHaveBeenLastCalledWith(Register.Pause, PauseOption.DHW);
+  });
+
+  it('preserves the ventilation pause bit when changing DHW pause', async () => {
+    const modbus = await createModbus();
+    client.readHoldingRegisters.mockResolvedValueOnce(registerResult([PauseOption.Ventilation]));
+
+    await expect(modbus.writeDHWPaused(true)).resolves.toBe(PauseOption.All);
+    expect(client.writeRegister).toHaveBeenLastCalledWith(Register.Pause, PauseOption.All);
+
+    client.readHoldingRegisters.mockResolvedValueOnce(registerResult([PauseOption.All]));
+    await expect(modbus.writeDHWPaused(false)).resolves.toBe(PauseOption.Ventilation);
+    expect(client.writeRegister).toHaveBeenLastCalledWith(Register.Pause, PauseOption.Ventilation);
   });
 });

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -1,0 +1,133 @@
+import type { API, Logger, PlatformAccessory, PlatformConfig } from 'homebridge';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { MockAccessoryHandler, handlers } = vi.hoisted(() => {
+  const handlers: Array<{ shutdown: ReturnType<typeof vi.fn> }> = [];
+  const MockAccessoryHandler = vi.fn(function MockAccessoryHandler() {
+    const handler = { shutdown: vi.fn() };
+    handlers.push(handler);
+    return handler;
+  });
+  return { MockAccessoryHandler, handlers };
+});
+
+vi.mock('../src/compactPAccessory', () => ({
+  CompactPPlatformAccessory: MockAccessoryHandler,
+}));
+
+import { NilanHomebridgePlatform } from '../src/platform';
+
+class FakePlatformAccessory {
+  public context: Record<string, unknown> = {};
+
+  constructor(
+    public readonly displayName: string,
+    public readonly UUID: string,
+  ) {}
+}
+
+function createHarness(devices: unknown[]) {
+  const listeners = new Map<string, () => void>();
+  const api = {
+    hap: {
+      Characteristic: {},
+      Service: {},
+      uuid: {
+        generate: vi.fn((host: string) => `uuid:${host}`),
+      },
+    },
+    on: vi.fn((event: string, listener: () => void) => {
+      listeners.set(event, listener);
+      return api;
+    }),
+    platformAccessory: FakePlatformAccessory,
+    registerPlatformAccessories: vi.fn(),
+    unregisterPlatformAccessories: vi.fn(),
+    updatePlatformAccessories: vi.fn(),
+  };
+  const log = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    log: vi.fn(),
+    prefix: 'test',
+    success: vi.fn(),
+    warn: vi.fn(),
+  };
+  const platform = new NilanHomebridgePlatform(
+    log as unknown as Logger,
+    { devices, name: 'Nilan', platform: 'Nilan' } as PlatformConfig,
+    api as unknown as API,
+  );
+  return { api, listeners, log, platform };
+}
+
+beforeEach(() => {
+  handlers.length = 0;
+});
+
+describe('NilanHomebridgePlatform discovery', () => {
+  it('registers unique valid devices and skips malformed or duplicate entries', () => {
+    const { api, log, platform } = createHarness([
+      { name: 'Living room', host: '192.0.2.10' },
+      { name: 'Duplicate', host: '192.0.2.10' },
+      { name: 'Missing host' },
+      { name: 'Utility room', host: '192.0.2.11' },
+    ]);
+
+    platform.discoverDevices();
+
+    expect(api.registerPlatformAccessories).toHaveBeenCalledTimes(2);
+    expect(MockAccessoryHandler).toHaveBeenCalledTimes(2);
+    expect(platform.accessories).toHaveLength(2);
+    expect(log.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('restores configured accessories and safely removes stale cache entries', () => {
+    const { api, platform } = createHarness([
+      { name: 'Configured', host: '192.0.2.10' },
+    ]);
+    const configured = new FakePlatformAccessory('Configured', 'uuid:192.0.2.10');
+    configured.context.device = { host: '192.0.2.10' };
+    const stale = new FakePlatformAccessory('Stale', 'uuid:192.0.2.99');
+
+    platform.configureAccessory(configured as unknown as PlatformAccessory);
+    platform.configureAccessory(stale as unknown as PlatformAccessory);
+    expect(() => platform.discoverDevices()).not.toThrow();
+
+    expect(api.registerPlatformAccessories).not.toHaveBeenCalled();
+    expect(api.updatePlatformAccessories).toHaveBeenCalledTimes(2);
+    expect(api.unregisterPlatformAccessories).toHaveBeenCalledWith(
+      'homebridge-nilan',
+      'Nilan',
+      [stale],
+    );
+    expect(platform.accessories).toEqual([configured]);
+  });
+
+  it('does not register the same accessory again on repeated discovery', () => {
+    const { api, platform } = createHarness([
+      { name: 'Configured', host: '192.0.2.10' },
+    ]);
+
+    platform.discoverDevices();
+    platform.discoverDevices();
+
+    expect(api.registerPlatformAccessories).toHaveBeenCalledOnce();
+    expect(api.updatePlatformAccessories).toHaveBeenCalledTimes(2);
+    expect(MockAccessoryHandler).toHaveBeenCalledOnce();
+  });
+
+  it('shuts down every active accessory handler', () => {
+    const { listeners, platform } = createHarness([
+      { name: 'First', host: '192.0.2.10' },
+      { name: 'Second', host: '192.0.2.11' },
+    ]);
+    platform.discoverDevices();
+
+    listeners.get('shutdown')!();
+
+    expect(handlers).toHaveLength(2);
+    expect(handlers.every(handler => handler.shutdown.mock.calls.length === 1)).toBe(true);
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -5,12 +5,12 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],
-      include: ['src/cts700Data.ts', 'src/cts700Modbus.ts'],
+      include: ['src/compactPAccessory.ts', 'src/cts700Data.ts', 'src/cts700Modbus.ts', 'src/platform.ts'],
       thresholds: {
-        lines: 70,
-        functions: 70,
-        branches: 65,
-        statements: 70,
+        lines: 80,
+        functions: 80,
+        branches: 70,
+        statements: 80,
       },
     },
     clearMocks: true,


### PR DESCRIPTION
## Summary

- read all 42 CTS700 week-program records across the three documented register blocks
- enforce the documented 10–65 °C domestic-hot-water setpoint range in both Modbus writes and HomeKit metadata
- retain signed 16-bit temperature decoding and safe async lifecycle handling from the original runtime-fix pass
- add regression coverage for the third schedule block and DHW limits

## Root causes addressed

- only the first two 14-record schedule blocks were modeled, so records 29–42 could never become active
- the DHW minimum was exposed as 5 °C even though CTS700 revision 2.01 documents 10 °C
- negative Modbus temperatures were previously interpreted as large unsigned values
- overlapping polling and shutdown races could leak work or surface avoidable errors

## Test expansion

The suite now contains 33 tests covering schedule selection, third-block reads, DHW limits and HomeKit properties, signed temperature decoding, polling overlap prevention, shutdown, and transport failures.

## Validation

- `npm run check`
- statements: 84.61%
- branches: 71.71%
- functions: 88.17%
- lines: 84.79%

Stacked on #14.
