### PR TITLE
Expand repository maintenance and security

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+Describe the change and why it is needed.
+
+## Validation
+
+- [ ] `npm run check` passes
+- [ ] Tests cover new or changed behavior
+- [ ] `npm audit` reports no known vulnerabilities
+- [ ] No generated `dist/` files or local Homebridge configuration are committed
+
+## Hardware impact
+
+- [ ] This change does not alter Modbus reads, writes, register mappings, polling, or HomeKit identities
+- [ ] Hardware-dependent behavior was tested with mocks
+- [ ] Hardware-dependent behavior was smoke-tested on a CTS700 Compact P, or the untested scope is explained below
+
+## Notes
+
+Document migration steps, compatibility changes, and anything reviewers cannot verify locally.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Ljubljana
+    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary
+    groups:
+      production-dependencies:
+        dependency-type: production
+      development-dependencies:
+        dependency-type: development
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 4 * * 3"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze JavaScript and TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@988661ebb5e81487b3fb31b2185d2856c0a10679 # v4
+        with:
+          build-mode: none
+          languages: javascript-typescript
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@988661ebb5e81487b3fb31b2185d2856c0a10679 # v4
+        with:
+          category: /language:javascript-typescript

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+Thanks for helping improve Homebridge Nilan.
+
+## Before opening a change
+
+- Search existing issues and pull requests for related work.
+- Keep changes focused. Protocol fixes, dependency maintenance, and documentation
+  are easier to review as separate pull requests.
+- Do not test against someone else's Nilan unit or commit real device addresses,
+  Homebridge configuration, credentials, logs, or generated `dist/` files.
+
+## Development setup
+
+Use Node.js 22 or 24. The repository's `.nvmrc` selects Node.js 22.
+
+```sh
+nvm use
+npm ci
+npm run check
+```
+
+`npm run check` runs linting, a strict TypeScript build, and the Vitest suite with
+coverage thresholds. Tests must use mocked Modbus I/O unless a maintainer has
+explicitly arranged hardware testing.
+
+See `AGENTS.md` for the source map, protocol invariants, HomeKit identity rules,
+and detailed validation guidance.
+
+## Pull requests
+
+- Explain the user-visible impact and root cause.
+- Add regression tests for bug fixes and focused tests for new behavior.
+- Keep `config.schema.json`, runtime configuration, and `README.md` aligned.
+- Call out any behavior that could not be tested on a real CTS700 Compact P.
+- Preserve plugin/platform identifiers, accessory UUID derivation, and HomeKit
+  service subtype strings unless the change intentionally includes a migration.
+
+## Reporting bugs
+
+Include the Homebridge version, plugin version, Node.js version, Compact P/CTS700
+details, configuration with secrets removed, relevant logs, and clear reproduction
+steps. Use GitHub's private vulnerability reporting for security-sensitive issues.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,42 @@
-<a href="https://homebridge.io"><img src="https://github.com/homebridge/branding/raw/master/logos/homebridge-color-round.png" height="70" alt="Homebridge logo"></a> &nbsp;<a href="https://www.nilan.dk"><img src="resources/images/nilan-logo.png" height="70" alt="Nilan logo"></a>
+<p align="center">
+  <a href="https://homebridge.io"><img src="https://raw.githubusercontent.com/homebridge/branding/latest/logos/homebridge-color-round.png" height="70" alt="Homebridge logo"></a>
+  &nbsp;
+  <a href="https://www.nilan.dk"><img src="resources/images/nilan-logo.png" height="70" alt="Nilan logo"></a>
+</p>
 
+# Homebridge Nilan
 
-# Nilan Homebridge Plugin
-
-This plugin enables [Apple HomeKit](https://developer.apple.com/homekit/) support for certain [Nilan](https://www.nilan.dk) devices via [Homebridge](https://homebridge.io).
+A [Homebridge](https://homebridge.io) dynamic-platform plugin that exposes a
+compatible [Nilan](https://www.nilan.dk) Compact P ventilation system to Apple
+Home. It communicates directly with the older CTS 700 controller over Modbus
+TCP; no cloud service is required.
 
 [![NPM Version](https://badgen.net/npm/v/homebridge-nilan)](https://www.npmjs.com/package/homebridge-nilan)
 [![CI](https://github.com/matej/homebridge-nilan/actions/workflows/build.yml/badge.svg)](https://github.com/matej/homebridge-nilan/actions/workflows/build.yml)
 
-**Apple Home App**
+## Compatibility
+
+| Component | Supported versions |
+| --- | --- |
+| Nilan controller | Compact P with the older, non-touchscreen CTS 700 panel |
+| Homebridge | 1.8 or 2.x |
+| Node.js | 22.10 or newer in the 22.x or 24.x release lines |
+| Connection | Modbus TCP, port 502 |
+
+The newer CTS 700 touchscreen panel uses a different protocol and is **not
+supported**.
+
+The plugin exposes ventilation state and fan speed, room temperature and target,
+domestic hot-water state and target, relative humidity, and outdoor and panel
+temperature. It polls the controller every 10 seconds.
+
+## Screenshots
+
+### Apple Home
 
 <img src="resources/screenshots/1.png" height="300" alt="Screenshot Apple Home App"> <img src="resources/screenshots/2.png" height="300" alt="Screenshot Apple Home App"> <img src="resources/screenshots/3.png" height="300" alt="Screenshot Apple Home App"> 
 
-**Elgato Eve App**
+### Eve
 
 <img src="resources/screenshots/4.png" height="300" alt="Screenshot Elgato Eve App"> <img src="resources/screenshots/5.png" height="300" alt="Screenshot Elgato Eve App">
 
@@ -20,120 +44,141 @@ This plugin enables [Apple HomeKit](https://developer.apple.com/homekit/) suppor
 
 ### Compact P
 
-[Compact P](https://www.nilan.dk/produkter/ventilation-med-opvarmning/ventilation-og-varmt-brugsvand/compact-p) ventilation and heating system with the CTS 700 control panel (older **non-touchscreen** version). The implementation is based on the [Modbus Registers Description document, dated 20150826](http://www.nilan.de/Admin/Public/Download.aspx?File=Files%2FFiler%2FDownload%2FFrench%2FDocumentation%2FGuide+dutilisation%2FModbus+CTS+700%2FModbus_Registers_Description_CTS700.pdf).
-
-Note that the new CTS 700 touchscreen control panel uses a different version of the communication protocol and hence needs a different implementation.
+[Compact P](https://www.nilan.dk/produkter/ventilation-med-opvarmning/ventilation-og-varmt-brugsvand/compact-p)
+ventilation and heating system with the older CTS 700 control panel. The
+implementation follows Nilan's *Modbus Registers Description* for CTS 700,
+dated 2015-08-26.
 
 <img src="resources/images/nilan-compact-p.png" height="200" alt="Nilan Compact P">
 
 ## Hardware Setup
 
-Use the built-in network cable to connect the Compact P to your home network. The unit's default IP address is `192.168.5.107`. You need to make sure you can reach the Compact P from the device that is hosting the Homebridge server (e.g., your [Raspberry Pi](https://www.raspberrypi.org)). If the Homebridge device is on the same network you have at least two options.
+Use the built-in network connection to connect the Compact P to your home
+network. Its default IP address is `192.168.5.107`. The machine running
+Homebridge must be able to reach that address on TCP port 502.
 
 ### Adjust the Device IP
 
-Adjust the Compact P network settings via the CTS 700 control panel. First switch to Super User mode (`Settings > Change user level`), then adjust the IP Address, Network mask and Network gateway to match your network configuration (using `Settings > Network settings`). Be sure to select a free IP address on your network that is outside of any DHCP server IP ranges.
+Adjust the Compact P network settings through the CTS 700 control panel. Switch
+to Super User mode under `Settings > Change user level`, then update the IP
+address, network mask, and gateway under `Settings > Network settings`. Reserve
+the address in your router or choose one outside its DHCP pool to avoid address
+conflicts.
 
 ### Add Second Subnet (Advanced)
 
-Adjust your router configuration to connect your current subnet to `192.168.1.0/24`. With this you can leave the default device settings and reach `192.168.5.107` from the rest of your network. 
+Alternatively, route your existing network to the Compact P's
+`192.168.5.0/24` subnet. This lets you keep the controller's default address.
 
-The exact details will differ depending on your router and IP range. Here's an example with `192.168.1.0/24` as the current subnet and a MikroTik router:
+The exact configuration depends on your router. For example, with a MikroTik
+router and `192.168.1.0/24` as the existing LAN:
 
-```
+```text
 ip address add interface=bridge1 address=192.168.5.1/24
+ip firewall filter add chain=forward src-address=192.168.1.0/24 dst-address=192.168.5.0/24 action=accept
+ip firewall filter add chain=forward src-address=192.168.5.0/24 dst-address=192.168.1.0/24 action=accept
 ```
 
-```
-ip fire fil add chain=forward src-address=192.168.1.0/24 dst-address=192.168.5.0/24 action=accept
-ip fire fil add chain=forward src-address=192.168.5.0/24 dst-address=192.168.1.0/24 action=accept
-```
+Only change routing and firewall rules if you understand their effect on your
+network.
 
 ## Software Setup
 
-1. Install Homebridge by following [the official wiki](https://github.com/homebridge/homebridge/wiki).
-1. Install this plugin using [Homebridge Config UI X](https://github.com/oznu/homebridge-config-ui-x), or by running `npm install -g homebridge-nilan`.
-1. Add the configuration to your homebridge [config.json](https://github.com/homebridge/homebridge/wiki/Homebridge-Config-JSON-Explained).
+1. Install Homebridge using the [official instructions](https://github.com/homebridge/homebridge/wiki).
+2. In [Homebridge UI](https://github.com/homebridge/homebridge-config-ui-x), search for `Homebridge Nilan` and select **Install**. Alternatively, run `npm install -g homebridge-nilan`.
+3. Configure the plugin in Homebridge UI, then restart Homebridge.
 
 ## Configuration
 
-This plugin supports [Homebridge Config UI X](https://github.com/oznu/homebridge-config-ui-x). You can use the web interface to configure all settings.
+Homebridge UI is the recommended way to configure the plugin. It validates the
+device IP address and writes the platform entry for you.
 
-Alternatively you can enable the plugin manually in [config.json](https://github.com/homebridge/homebridge/wiki/Homebridge-Config-JSON-Explained). Here's an example entry in the platforms array:
+For manual configuration, add an entry to the `platforms` array in Homebridge's
+[`config.json`](https://github.com/homebridge/homebridge/wiki/Homebridge-Config-JSON-Explained):
 
 ```json
-"platforms": [
+{
+  "platforms": [
     {
-        "devices": [
-            {
-                "name": "Compact P",
-                "host": "192.168.5.107",
-                "schedule": true
-            }
-        ],
-        "platform": "Nilan"
+      "platform": "Nilan",
+      "devices": [
+        {
+          "name": "Compact P",
+          "host": "192.168.5.107",
+          "schedule": true
+        }
+      ]
     }
-]
+  ]
+}
 ```
 
-Be sure to update the `host` parameter to match your device (if you changed the IP). 
+| Option | Required | Description |
+| --- | --- | --- |
+| `platform` | Yes | Must remain `Nilan`. |
+| `devices` | Yes | One or more Compact P controller definitions. |
+| `devices[].name` | Yes | Display name for the HomeKit accessory. |
+| `devices[].host` | Yes | IPv4 address of the controller. |
+| `devices[].schedule` | No | Synchronize setpoints and fan speed with the CTS 700 week program; defaults to `true`. |
+
+Give each configured device a unique IP address. If you change a device's
+`host`, Homebridge treats it as a new accessory because the IP address is part
+of its persistent identity.
 
 ### Schedule
 
-The `schedule` option should be enabled if you have a week schedule programmed on your control unit. The option ensures that the values reported in HomeKit update when the week program changes. Otherwise HomeKit just reflects the last user-set value.
+Enable `schedule` when a week program is active on the controller. The plugin
+then keeps HomeKit's room-temperature target, hot-water target, and fan speed in
+sync with the active schedule entry. This synchronization can write those three
+values back to the controller. Set the option to `false` if no week program is
+configured or if HomeKit should retain the last manually selected values.
+
+## Troubleshooting
+
+- Confirm that the Homebridge host can reach the controller's IP address and TCP
+  port 502.
+- Confirm that the panel is the older, non-touchscreen CTS 700 model.
+- Check that every device has a unique `host` value and that no other Modbus
+  client is monopolizing the connection.
+- Run Homebridge in debug mode and include the relevant logs, with addresses and
+  credentials removed, when opening an issue.
 
 ## Developer Notes
 
-### Setup Development Environment
+Use Node.js 22 or 24. The repository's `.nvmrc` selects Node.js 22.
 
-This plugin requires Node.js 22 or 24 and a modern code editor such as [VS Code](https://code.visualstudio.com/). It uses [TypeScript](https://www.typescriptlang.org/) and comes with pre-configured settings for [VS Code](https://code.visualstudio.com/) and ESLint. If you are using VS Code install these extensions:
-
-* [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
-
-### Install Development Dependencies
-
-Using a terminal, navigate to the project folder and run this command to install the development dependencies:
-
-```
+```sh
+nvm use
 npm ci
+npm run check
 ```
 
-### Build Plugin
+The combined check lints the project, performs a strict TypeScript build, and
+runs the mocked Vitest suite with coverage. Individual commands are also
+available:
 
-TypeScript needs to be compiled into JavaScript before it can run. The following command will compile the contents of your [`src`](./src) directory and put the resulting code into the `dist` folder.
-
-```
+```sh
+npm run lint
 npm run build
+npm test
 ```
 
-### Link to Homebridge
+For explicitly prepared local hardware development only:
 
-Run this command so your global install of Homebridge can discover the plugin in your development environment:
-
-```
-npm link
-```
-
-You can now start Homebridge, use the `-D` flag so you can see debug log messages in your plugin:
-
-```
-homebridge -D
-```
-
-### Watch for Changes and Build Automatically
-
-If you want to have your code compile automatically as you make changes, and restart Homebridge automatically between changes you can run:
-
-```
+```sh
 npm run watch
 ```
 
-This will launch an instance of Homebridge in debug mode which will restart every time you make a change to the source code. It will load the config stored in the default location under `~/.homebridge`. You may need to stop other running instances of Homebridge while using this command to prevent conflicts. You can adjust the Homebridge startup command in the [`nodemon.json`](./nodemon.json) file.
+This command links the package and launches Homebridge in debug mode using the
+default `~/.homebridge` configuration. It may connect to and write to a real
+controller, so do not use it as routine validation.
 
 ## Contributing and Security
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development and pull request guidance.
-Report security-sensitive issues according to [SECURITY.md](SECURITY.md), not in a public issue.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development and pull request guidance
+and [AGENTS.md](AGENTS.md) for architecture and protocol invariants. Report
+security-sensitive issues according to [SECURITY.md](SECURITY.md), not in a
+public issue.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 This plugin enables [Apple HomeKit](https://developer.apple.com/homekit/) support for certain [Nilan](https://www.nilan.dk) devices via [Homebridge](https://homebridge.io).
 
 [![NPM Version](https://badgen.net/npm/v/homebridge-nilan)](https://www.npmjs.com/package/homebridge-nilan)
-![Build and Lint](https://github.com/matej/homebridge-nilan/workflows/Build%20and%20Lint/badge.svg)
+[![CI](https://github.com/matej/homebridge-nilan/actions/workflows/build.yml/badge.svg)](https://github.com/matej/homebridge-nilan/actions/workflows/build.yml)
 
 **Apple Home App**
 
@@ -30,11 +30,11 @@ Note that the new CTS 700 touchscreen control panel uses a different version of 
 
 Use the built-in network cable to connect the Compact P to your home network. The unit's default IP address is `192.168.5.107`. You need to make sure you can reach the Compact P from the device that is hosting the Homebridge server (e.g., your [Raspberry Pi](https://www.raspberrypi.org)). If the Homebridge device is on the same network you have at least two options.
 
-#### Adjust the Device IP
+### Adjust the Device IP
 
-Adjust the Compact P network settings via the CTS 700 control panel. First Switch to Super User mode (`Settings > Change user level`), then adjust the IP Address, Network mask and Network gateway to match your network configuration (using `Settings > Network settings`). Be sure to select a free IP address on your network that is outside of any DHCP server IP ranges:
+Adjust the Compact P network settings via the CTS 700 control panel. First switch to Super User mode (`Settings > Change user level`), then adjust the IP Address, Network mask and Network gateway to match your network configuration (using `Settings > Network settings`). Be sure to select a free IP address on your network that is outside of any DHCP server IP ranges.
 
-#### Add Second Subnet (Advanced)
+### Add Second Subnet (Advanced)
 
 Adjust your router configuration to connect your current subnet to `192.168.1.0/24`. With this you can leave the default device settings and reach `192.168.5.107` from the rest of your network. 
 
@@ -80,27 +80,25 @@ Be sure to update the `host` parameter to match your device (if you changed the 
 
 ### Schedule
 
-The `schedule` option should be enabled, if you have a week schedule programmed on your control unit. The option ensures that the values reported in HomeKit update when the week program changes. Otherwise HmeKit just reflects the last set user value.
+The `schedule` option should be enabled if you have a week schedule programmed on your control unit. The option ensures that the values reported in HomeKit update when the week program changes. Otherwise HomeKit just reflects the last user-set value.
 
-# Developer Notes
+## Developer Notes
 
-## Setup Development Environment
+### Setup Development Environment
 
 This plugin requires Node.js 22 or 24 and a modern code editor such as [VS Code](https://code.visualstudio.com/). It uses [TypeScript](https://www.typescriptlang.org/) and comes with pre-configured settings for [VS Code](https://code.visualstudio.com/) and ESLint. If you are using VS Code install these extensions:
 
 * [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 
-## Install Development Dependencies
+### Install Development Dependencies
 
 Using a terminal, navigate to the project folder and run this command to install the development dependencies:
 
 ```
-npm install
+npm ci
 ```
 
-You might need to run this command with `sudo`.
-
-## Build Plugin
+### Build Plugin
 
 TypeScript needs to be compiled into JavaScript before it can run. The following command will compile the contents of your [`src`](./src) directory and put the resulting code into the `dist` folder.
 
@@ -108,7 +106,7 @@ TypeScript needs to be compiled into JavaScript before it can run. The following
 npm run build
 ```
 
-## Link to Homebridge
+### Link to Homebridge
 
 Run this command so your global install of Homebridge can discover the plugin in your development environment:
 
@@ -122,7 +120,7 @@ You can now start Homebridge, use the `-D` flag so you can see debug log message
 homebridge -D
 ```
 
-## Watch for Changes and Build Automatically
+### Watch for Changes and Build Automatically
 
 If you want to have your code compile automatically as you make changes, and restart Homebridge automatically between changes you can run:
 
@@ -132,10 +130,15 @@ npm run watch
 
 This will launch an instance of Homebridge in debug mode which will restart every time you make a change to the source code. It will load the config stored in the default location under `~/.homebridge`. You may need to stop other running instances of Homebridge while using this command to prevent conflicts. You can adjust the Homebridge startup command in the [`nodemon.json`](./nodemon.json) file.
 
-# Disclaimer
+## Contributing and Security
 
-The plugin is based on the open Nilan Modbus protocol and only accesses user-level registers without needing any privileged access. While the plugin was extensively tested on the author's own hardware, there is no guarantees given that the it will perform without issues in other environments. Please proceed at your own risk.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development and pull request guidance.
+Report security-sensitive issues according to [SECURITY.md](SECURITY.md), not in a public issue.
 
-This plugin, or it's author is in no way associated with Nilan A/S.  
+## Disclaimer
 
-Nilan is a registered trademark of [Nilan A/S]((https://www.nilan.dk)).
+The plugin is based on the open Nilan Modbus protocol and only accesses user-level registers without needing any privileged access. While the plugin was extensively tested on the author's own hardware, there are no guarantees that it will perform without issues in other environments. Please proceed at your own risk.
+
+This plugin and its author are not associated with Nilan A/S.
+
+Nilan is a registered trademark of [Nilan A/S](https://www.nilan.dk).

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ temperature. It polls the controller every 10 seconds.
 
 [Compact P](https://www.nilan.dk/produkter/ventilation-med-opvarmning/ventilation-og-varmt-brugsvand/compact-p)
 ventilation and heating system with the older CTS 700 control panel. The
-implementation follows Nilan's *Modbus Registers Description* for CTS 700,
-dated 2015-08-26.
+implementation follows Nilan's *CTS 700 Modbus Registers Description*, revision
+2.01 (last updated 2016-03-11). Nilan no longer hosts it at its original URL, but
+a [preserved copy is available from the Internet Archive](https://web.archive.org/web/20250204012946id_/https://symlink.dk/stuff/CTS700_MODBUS-rev%202.01.pdf).
 
 <img src="resources/images/nilan-compact-p.png" height="200" alt="Nilan Compact P">
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are provided for the latest published version of
+`homebridge-nilan`. Users should also run a supported Node.js and Homebridge
+release.
+
+## Reporting a vulnerability
+
+Do not disclose suspected vulnerabilities in a public issue. Use the repository's
+GitHub **Report a vulnerability** flow under the Security tab. If that option is
+not available, contact the maintainer privately through the contact information on
+their GitHub profile and include a minimal description without exploit details.
+
+Please include affected versions, impact, reproduction steps or a proof of concept,
+and any suggested mitigation. You should receive an acknowledgement within seven
+days. A coordinated disclosure timeline will be agreed after the report is
+validated.

--- a/config.schema.json
+++ b/config.schema.json
@@ -24,10 +24,10 @@
             "description": "Check the control panel in Super user mode under Settings -> Network Settings. Make sure you can ping the Nilan unit from your Homebridge device."
           },
           "schedule": {
-            "title": "Adjust for week schedule.",
+            "title": "Synchronize with week schedule",
             "type": "boolean",
             "default": true,
-            "description": "This option should be enabled, if you have a week schedule programmed on your control unit. The option ensures that the values reported in HomeKit update when the week program changes. Otherwise HmeKit just reflects the last set user value."
+            "description": "Enable this when a week schedule is programmed on the controller. The plugin keeps the HomeKit room-temperature target, hot-water target, and fan speed synchronized with the active schedule entry."
           }
         }
       }


### PR DESCRIPTION
## Summary

- repair the Homebridge logo and replace the dead CTS700 protocol link with an archived revision 2.01 reference
- refresh installation, compatibility, configuration, development, troubleshooting, and project-status documentation
- add CI status and project metadata badges
- add Dependabot configuration and repository maintenance templates
- carry forward the CTS700 protocol-alignment fixes from #15

## Validation

- `npm run check`
- 33 tests pass
- CI, CodeQL, dependency review, and package smoke-test workflows are included in the stacked changes

Stacked on #15.
