### PR TITLE
Expose CTS700 filter maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ The newer CTS 700 touchscreen panel uses a different protocol and is **not
 supported**.
 
 The plugin exposes ventilation state and fan speed, room temperature and target,
-domestic hot-water state and target, relative humidity, and outdoor and panel
-temperature. It polls the controller every 10 seconds.
+domestic hot-water state and target, relative humidity, inlet and outlet filter
+life and reset controls, and outdoor and panel temperature. It polls the
+controller every 10 seconds.
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ The newer CTS 700 touchscreen panel uses a different protocol and is **not
 supported**.
 
 The plugin exposes ventilation state and fan speed, room temperature and target,
-domestic hot-water state and target, relative humidity, inlet and outlet filter
-life and reset controls, and outdoor and panel temperature. It polls the
-controller every 10 seconds.
+domestic hot-water state and target, relative humidity, time-based inlet and
+outlet filter life and reset controls, and outdoor and panel temperature. It
+polls the controller every 10 seconds.
 
 ## Screenshots
 

--- a/src/compactPAccessory.ts
+++ b/src/compactPAccessory.ts
@@ -266,8 +266,18 @@ export class CompactPPlatformAccessory {
       this.panelTemperatureSensorService.updateCharacteristic(c.CurrentTemperature, readings.panelTemperature);
       this.ventilationThermostatService.updateCharacteristic(c.CurrentRelativeHumidity, readings.actualHumidity);
       this.dhwThermostatService.updateCharacteristic(c.CurrentTemperature, readings.dhwTankTopTemperature);
-      this.updateFilterMaintenance(this.inletFilterMaintenanceService, readings.inletFilterDeterioration, c);
-      this.updateFilterMaintenance(this.outletFilterMaintenanceService, readings.outletFilterDeterioration, c);
+      this.updateFilterMaintenance(
+        this.inletFilterMaintenanceService,
+        readings.inletFilterElapsedDays,
+        readings.inletFilterReplacementInterval,
+        c,
+      );
+      this.updateFilterMaintenance(
+        this.outletFilterMaintenanceService,
+        readings.outletFilterElapsedDays,
+        readings.outletFilterReplacementInterval,
+        c,
+      );
 
       // The schedule only has minute precision, so we can ignore checks if at least a minute didn't pass. 
       const normalizedDateTime = readings.currentDateTime;
@@ -350,9 +360,17 @@ export class CompactPPlatformAccessory {
     }
   }
 
-  private updateFilterMaintenance(service: Service, deterioration: number, c: NilanHomebridgePlatform['Characteristic']): void {
-    const filterLifeLevel = 100 - deterioration;
-    const changeIndication = deterioration >= 100 ? c.FilterChangeIndication.CHANGE_FILTER : c.FilterChangeIndication.FILTER_OK;
+  private updateFilterMaintenance(
+    service: Service,
+    elapsedDays: number,
+    replacementInterval: number,
+    c: NilanHomebridgePlatform['Characteristic'],
+  ): void {
+    const remainingDays = Math.max(0, replacementInterval - elapsedDays);
+    const filterLifeLevel = Math.round(remainingDays / replacementInterval * 100);
+    const changeIndication = elapsedDays >= replacementInterval
+      ? c.FilterChangeIndication.CHANGE_FILTER
+      : c.FilterChangeIndication.FILTER_OK;
     service.updateCharacteristic(c.FilterLifeLevel, filterLifeLevel);
     service.updateCharacteristic(c.FilterChangeIndication, changeIndication);
   }

--- a/src/compactPAccessory.ts
+++ b/src/compactPAccessory.ts
@@ -14,6 +14,8 @@ export class CompactPPlatformAccessory {
   private dhwThermostatService: Service;
   private outsideTemperatureSensorService: Service;
   private panelTemperatureSensorService: Service;
+  private inletFilterMaintenanceService: Service;
+  private outletFilterMaintenanceService: Service;
   
   private cts700Modbus: CTS700Modbus;
   private readonly updateInterval: ReturnType<typeof setInterval>;
@@ -42,6 +44,20 @@ export class CompactPPlatformAccessory {
     this.dhwThermostatService = this.setUpDHWThermostat(platform, accessory);
     this.outsideTemperatureSensorService = this.setUpOutsideTemperatureSensor(platform, accessory);
     this.panelTemperatureSensorService = this.setUpPanelTemperatureSensor(platform, accessory);
+    this.inletFilterMaintenanceService = this.setUpFilterMaintenance(
+      platform,
+      accessory,
+      'Inlet Filter',
+      'compact-p-inlet-filter',
+      () => this.cts700Modbus.resetInletFilter(),
+    );
+    this.outletFilterMaintenanceService = this.setUpFilterMaintenance(
+      platform,
+      accessory,
+      'Outlet Filter',
+      'compact-p-outlet-filter',
+      () => this.cts700Modbus.resetOutletFilter(),
+    );
 
     this.updateInterval = setInterval(() => {
       void this.updateFromDevice(platform);
@@ -209,6 +225,29 @@ export class CompactPPlatformAccessory {
     return panelTemperatureSensorService;
   }
 
+  private setUpFilterMaintenance(
+    platform: NilanHomebridgePlatform,
+    accessory: PlatformAccessory,
+    name: string,
+    subtype: string,
+    reset: () => Promise<number>,
+  ): Service {
+    const filterMaintenanceService = this.accessory.getServiceById(platform.Service.FilterMaintenance, subtype) ||
+      accessory.addService(platform.Service.FilterMaintenance, name, subtype);
+
+    const c = platform.Characteristic;
+    filterMaintenanceService.getCharacteristic(c.ResetFilterIndication)
+      .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+        if (value !== 1) {
+          callback(null);
+          return;
+        }
+        this.handleWrite(() => reset(), value as number, `${name} reset`, callback);
+      });
+
+    return filterMaintenanceService;
+  }
+
   private async updateFromDevice(platform: NilanHomebridgePlatform) {
     if (this.updateInProgress) {
       this.platform.log.debug('Skipping device update because the previous poll is still running.');
@@ -227,6 +266,8 @@ export class CompactPPlatformAccessory {
       this.panelTemperatureSensorService.updateCharacteristic(c.CurrentTemperature, readings.panelTemperature);
       this.ventilationThermostatService.updateCharacteristic(c.CurrentRelativeHumidity, readings.actualHumidity);
       this.dhwThermostatService.updateCharacteristic(c.CurrentTemperature, readings.dhwTankTopTemperature);
+      this.updateFilterMaintenance(this.inletFilterMaintenanceService, readings.inletFilterDeterioration, c);
+      this.updateFilterMaintenance(this.outletFilterMaintenanceService, readings.outletFilterDeterioration, c);
 
       // The schedule only has minute precision, so we can ignore checks if at least a minute didn't pass. 
       const normalizedDateTime = readings.currentDateTime;
@@ -307,6 +348,13 @@ export class CompactPPlatformAccessory {
     } finally {
       this.updateInProgress = false;
     }
+  }
+
+  private updateFilterMaintenance(service: Service, deterioration: number, c: NilanHomebridgePlatform['Characteristic']): void {
+    const filterLifeLevel = 100 - deterioration;
+    const changeIndication = deterioration >= 100 ? c.FilterChangeIndication.CHANGE_FILTER : c.FilterChangeIndication.FILTER_OK;
+    service.updateCharacteristic(c.FilterLifeLevel, filterLifeLevel);
+    service.updateCharacteristic(c.FilterChangeIndication, changeIndication);
   }
 
   private async handleWrite<T extends WriterParameter, R extends WriterParameter>(

--- a/src/cts700Data.ts
+++ b/src/cts700Data.ts
@@ -19,10 +19,12 @@ export enum Register {
 	OutdoorTemperature = 5152,
 	// ActualHumidity is ID of register holding actual humidity value
 	ActualHumidity = 4716,
-	// Filter deterioration is reported as 0% for a new filter and 100% when replacement is due.
-	InletFilterDeterioration = 4692,
-	OutletFilterDeterioration = 4693,
-	// Writing 1 resets the corresponding filter deterioration counter.
+	// Software filter replacement intervals and elapsed times are measured in days.
+	InletFilterReplacementInterval = 1326,
+	OutletFilterReplacementInterval = 1327,
+	InletFilterElapsedDays = 1328,
+	OutletFilterElapsedDays = 1329,
+	// Writing 1 resets the corresponding software filter elapsed-time counter.
 	InletFilterReset = 4756,
 	OutletFilterReset = 4757,
 	// DHWTopTankTemperature is ID of register holding T11 top DHW tank temperature
@@ -139,10 +141,11 @@ export interface Readings {
 	panelTemperature: number;
 	// Actual humidity of air (0-100%)
 	actualHumidity: number;
-	// Inlet filter deterioration (0-100%)
-	inletFilterDeterioration: number;
-	// Outlet filter deterioration (0-100%)
-	outletFilterDeterioration: number;
+	// Software filter replacement intervals and elapsed times in days.
+	inletFilterReplacementInterval: number;
+	inletFilterElapsedDays: number;
+	outletFilterReplacementInterval: number;
+	outletFilterElapsedDays: number;
 	// DHW tank top temperature in C times 10
 	dhwTankTopTemperature: number;
 	// Current device time.

--- a/src/cts700Data.ts
+++ b/src/cts700Data.ts
@@ -19,6 +19,12 @@ export enum Register {
 	OutdoorTemperature = 5152,
 	// ActualHumidity is ID of register holding actual humidity value
 	ActualHumidity = 4716,
+	// Filter deterioration is reported as 0% for a new filter and 100% when replacement is due.
+	InletFilterDeterioration = 4692,
+	OutletFilterDeterioration = 4693,
+	// Writing 1 resets the corresponding filter deterioration counter.
+	InletFilterReset = 4756,
+	OutletFilterReset = 4757,
 	// DHWTopTankTemperature is ID of register holding T11 top DHW tank temperature
 	DHWTopTankTemperature = 5162,
 	// DHWBottomTankTemperature is ID of register holding T12 bottom DHW tank temperature
@@ -133,6 +139,10 @@ export interface Readings {
 	panelTemperature: number;
 	// Actual humidity of air (0-100%)
 	actualHumidity: number;
+	// Inlet filter deterioration (0-100%)
+	inletFilterDeterioration: number;
+	// Outlet filter deterioration (0-100%)
+	outletFilterDeterioration: number;
 	// DHW tank top temperature in C times 10
 	dhwTankTopTemperature: number;
 	// Current device time.

--- a/src/cts700Modbus.ts
+++ b/src/cts700Modbus.ts
@@ -125,6 +125,8 @@ export class CTS700Modbus {
       outdoorTemperature: await this.readTemperatureRegister(Register.OutdoorTemperature),
       panelTemperature: await this.readTemperatureRegister(Register.PanelTemperature),
       actualHumidity: await this.readPercentageRegister(Register.ActualHumidity),
+      inletFilterDeterioration: await this.readPercentageRegister(Register.InletFilterDeterioration),
+      outletFilterDeterioration: await this.readPercentageRegister(Register.OutletFilterDeterioration),
       dhwTankTopTemperature: await this.readTemperatureRegister(Register.DHWTopTankTemperature),
       currentDateTime: await this.readDateTimeRegister(Register.CurrentTime),
     };
@@ -334,6 +336,14 @@ export class CTS700Modbus {
 
   public async writeDHWPaused(paused: boolean): Promise<PauseOption> {
     return this.writePauseComponent(PauseOption.DHW, paused);
+  }
+
+  public async resetInletFilter(): Promise<number> {
+    return this.writeSingleRegister(Register.InletFilterReset, 1);
+  }
+
+  public async resetOutletFilter(): Promise<number> {
+    return this.writeSingleRegister(Register.OutletFilterReset, 1);
   }
 
   public async writeVentilationMode(value: VentilationMode): Promise<VentilationMode> {

--- a/src/cts700Modbus.ts
+++ b/src/cts700Modbus.ts
@@ -125,8 +125,10 @@ export class CTS700Modbus {
       outdoorTemperature: await this.readTemperatureRegister(Register.OutdoorTemperature),
       panelTemperature: await this.readTemperatureRegister(Register.PanelTemperature),
       actualHumidity: await this.readPercentageRegister(Register.ActualHumidity),
-      inletFilterDeterioration: await this.readPercentageRegister(Register.InletFilterDeterioration),
-      outletFilterDeterioration: await this.readPercentageRegister(Register.OutletFilterDeterioration),
+      inletFilterReplacementInterval: await this.readFilterReplacementInterval(Register.InletFilterReplacementInterval),
+      inletFilterElapsedDays: await this.readFilterElapsedDays(Register.InletFilterElapsedDays),
+      outletFilterReplacementInterval: await this.readFilterReplacementInterval(Register.OutletFilterReplacementInterval),
+      outletFilterElapsedDays: await this.readFilterElapsedDays(Register.OutletFilterElapsedDays),
       dhwTankTopTemperature: await this.readTemperatureRegister(Register.DHWTopTankTemperature),
       currentDateTime: await this.readDateTimeRegister(Register.CurrentTime),
     };
@@ -173,6 +175,26 @@ export class CTS700Modbus {
       .then((result) => {
         if (result < 0 || result > 100) {
           throw Error('Value outside of acceptable range.');
+        }
+        return result;
+      });
+  }
+
+  private async readFilterReplacementInterval(register: Register): Promise<number> {
+    return this.readSingleRegister(register)
+      .then((result) => {
+        if (result < 30 || result > 360) {
+          throw Error('Filter replacement interval outside of acceptable range.');
+        }
+        return result;
+      });
+  }
+
+  private async readFilterElapsedDays(register: Register): Promise<number> {
+    return this.readSingleRegister(register)
+      .then((result) => {
+        if (result > 360) {
+          throw Error('Filter elapsed time outside of acceptable range.');
         }
         return result;
       });

--- a/test/compactPAccessory.test.ts
+++ b/test/compactPAccessory.test.ts
@@ -60,9 +60,12 @@ function createHarness(schedule = false) {
     CurrentRelativeHumidity: Symbol('CurrentRelativeHumidity'),
     CurrentTemperature: Symbol('CurrentTemperature'),
     FirmwareRevision: Symbol('FirmwareRevision'),
+    FilterChangeIndication: Object.assign(Symbol('FilterChangeIndication'), { CHANGE_FILTER: 1, FILTER_OK: 0 }),
+    FilterLifeLevel: Symbol('FilterLifeLevel'),
     Manufacturer: Symbol('Manufacturer'),
     Model: Symbol('Model'),
     RotationSpeed: Symbol('RotationSpeed'),
+    ResetFilterIndication: Symbol('ResetFilterIndication'),
     SerialNumber: Symbol('SerialNumber'),
     TargetHeatingCoolingState: Object.assign(Symbol('TargetHeatingCoolingState'), { AUTO: 3, COOL: 2, HEAT: 1, OFF: 0 }),
     TargetTemperature: Symbol('TargetTemperature'),
@@ -71,6 +74,7 @@ function createHarness(schedule = false) {
   const ServiceTypes = {
     AccessoryInformation: Symbol('AccessoryInformation'),
     Fanv2: Symbol('Fanv2'),
+    FilterMaintenance: Symbol('FilterMaintenance'),
     TemperatureSensor: Symbol('TemperatureSensor'),
     Thermostat: Symbol('Thermostat'),
   };
@@ -100,6 +104,8 @@ function createHarness(schedule = false) {
     fetchMetadata: vi.fn().mockResolvedValue({ macAddress: '00:11:22:33:44:55', softwareVersion: '1.2.3' }),
     fetchReadings: vi.fn().mockResolvedValue({
       actualHumidity: 48,
+      inletFilterDeterioration: 25,
+      outletFilterDeterioration: 100,
       currentDateTime: { second: 1, minute: 2, hour: 3, day: 4, weekDay: 5, month: 6, year: 26 },
       dhwTankTopTemperature: 51,
       outdoorTemperature: -5,
@@ -117,6 +123,8 @@ function createHarness(schedule = false) {
     writeDHWPaused: vi.fn().mockResolvedValue(PauseOption.Disabled),
     writeDHWSetPoint: vi.fn().mockResolvedValue(50),
     writeFanSpeed: vi.fn().mockResolvedValue(60),
+    resetInletFilter: vi.fn().mockResolvedValue(1),
+    resetOutletFilter: vi.fn().mockResolvedValue(1),
     writeRoomTemperatureSetPoint: vi.fn().mockResolvedValue(22),
     writeVentilationMode: vi.fn().mockResolvedValue(VentilationMode.Auto),
     writeVentilationPaused: vi.fn().mockResolvedValue(PauseOption.Disabled),
@@ -191,6 +199,27 @@ describe('CompactPPlatformAccessory', () => {
     expect(services.get('compact-p-temperature')!.updates).toContainEqual([Characteristic.CurrentTemperature, 21]);
     expect(services.get('compact-p-fan')!.updates).toContainEqual([Characteristic.RotationSpeed, 60]);
     expect(services.get('compact-p-dhw')!.updates).toContainEqual([Characteristic.TargetTemperature, 50]);
+    expect(services.get('compact-p-inlet-filter')!.updates).toContainEqual([Characteristic.FilterLifeLevel, 75]);
+    expect(services.get('compact-p-inlet-filter')!.updates).toContainEqual([
+      Characteristic.FilterChangeIndication,
+      Characteristic.FilterChangeIndication.FILTER_OK,
+    ]);
+    expect(services.get('compact-p-outlet-filter')!.updates).toContainEqual([Characteristic.FilterLifeLevel, 0]);
+    expect(services.get('compact-p-outlet-filter')!.updates).toContainEqual([
+      Characteristic.FilterChangeIndication,
+      Characteristic.FilterChangeIndication.CHANGE_FILTER,
+    ]);
+  });
+
+  it('resets inlet and outlet filter counters from HomeKit', async () => {
+    const { Characteristic, modbus, services } = createHarness();
+
+    await invokeSet(services.get('compact-p-inlet-filter')!, Characteristic.ResetFilterIndication, 0);
+    await invokeSet(services.get('compact-p-inlet-filter')!, Characteristic.ResetFilterIndication, 1);
+    await invokeSet(services.get('compact-p-outlet-filter')!, Characteristic.ResetFilterIndication, 1);
+
+    expect(modbus.resetInletFilter).toHaveBeenCalledOnce();
+    expect(modbus.resetOutletFilter).toHaveBeenCalledOnce();
   });
 
   it('does not overlap slow polling cycles', async () => {
@@ -206,6 +235,8 @@ describe('CompactPPlatformAccessory', () => {
 
     resolveReadings!({
       actualHumidity: 48,
+      inletFilterDeterioration: 25,
+      outletFilterDeterioration: 100,
       currentDateTime: { second: 1, minute: 2, hour: 3, day: 4, weekDay: 5, month: 6, year: 26 },
       dhwTankTopTemperature: 51,
       outdoorTemperature: -5,

--- a/test/compactPAccessory.test.ts
+++ b/test/compactPAccessory.test.ts
@@ -1,7 +1,7 @@
 import type { CharacteristicSetCallback, CharacteristicValue, PlatformAccessory } from 'homebridge';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { OperationMode, PauseOption, VentilationMode } from '../src/cts700Data';
+import { OperationMode, PauseOption, type Readings, VentilationMode } from '../src/cts700Data';
 import type { CTS700Modbus } from '../src/cts700Modbus';
 
 vi.mock('homebridge', () => ({
@@ -53,7 +53,7 @@ class FakeService {
   }
 }
 
-function createHarness(schedule = false) {
+function createHarness(schedule = false, readingOverrides: Partial<Readings> = {}) {
   const Characteristic = {
     Active: Object.assign(Symbol('Active'), { ACTIVE: 1, INACTIVE: 0 }),
     CurrentHeatingCoolingState: Object.assign(Symbol('CurrentHeatingCoolingState'), { COOL: 2, HEAT: 1, OFF: 0 }),
@@ -104,13 +104,16 @@ function createHarness(schedule = false) {
     fetchMetadata: vi.fn().mockResolvedValue({ macAddress: '00:11:22:33:44:55', softwareVersion: '1.2.3' }),
     fetchReadings: vi.fn().mockResolvedValue({
       actualHumidity: 48,
-      inletFilterDeterioration: 25,
-      outletFilterDeterioration: 100,
+      inletFilterReplacementInterval: 90,
+      inletFilterElapsedDays: 59,
+      outletFilterReplacementInterval: 90,
+      outletFilterElapsedDays: 90,
       currentDateTime: { second: 1, minute: 2, hour: 3, day: 4, weekDay: 5, month: 6, year: 26 },
       dhwTankTopTemperature: 51,
       outdoorTemperature: -5,
       panelTemperature: 20,
       roomTemperature: 21,
+      ...readingOverrides,
     }),
     fetchSettings: vi.fn().mockResolvedValue({
       dhwTemperatureSetPoint: 50,
@@ -199,7 +202,7 @@ describe('CompactPPlatformAccessory', () => {
     expect(services.get('compact-p-temperature')!.updates).toContainEqual([Characteristic.CurrentTemperature, 21]);
     expect(services.get('compact-p-fan')!.updates).toContainEqual([Characteristic.RotationSpeed, 60]);
     expect(services.get('compact-p-dhw')!.updates).toContainEqual([Characteristic.TargetTemperature, 50]);
-    expect(services.get('compact-p-inlet-filter')!.updates).toContainEqual([Characteristic.FilterLifeLevel, 75]);
+    expect(services.get('compact-p-inlet-filter')!.updates).toContainEqual([Characteristic.FilterLifeLevel, 34]);
     expect(services.get('compact-p-inlet-filter')!.updates).toContainEqual([
       Characteristic.FilterChangeIndication,
       Characteristic.FilterChangeIndication.FILTER_OK,
@@ -222,6 +225,26 @@ describe('CompactPPlatformAccessory', () => {
     expect(modbus.resetOutletFilter).toHaveBeenCalledOnce();
   });
 
+  it('clamps time-based filter life at reset and when overdue', async () => {
+    const { Characteristic, services } = createHarness(false, {
+      inletFilterElapsedDays: 0,
+      outletFilterElapsedDays: 100,
+    });
+
+    await vi.advanceTimersByTimeAsync(10000);
+
+    expect(services.get('compact-p-inlet-filter')!.updates).toContainEqual([Characteristic.FilterLifeLevel, 100]);
+    expect(services.get('compact-p-inlet-filter')!.updates).toContainEqual([
+      Characteristic.FilterChangeIndication,
+      Characteristic.FilterChangeIndication.FILTER_OK,
+    ]);
+    expect(services.get('compact-p-outlet-filter')!.updates).toContainEqual([Characteristic.FilterLifeLevel, 0]);
+    expect(services.get('compact-p-outlet-filter')!.updates).toContainEqual([
+      Characteristic.FilterChangeIndication,
+      Characteristic.FilterChangeIndication.CHANGE_FILTER,
+    ]);
+  });
+
   it('does not overlap slow polling cycles', async () => {
     const { modbus } = createHarness();
     let resolveReadings: ((value: unknown) => void) | undefined;
@@ -235,8 +258,10 @@ describe('CompactPPlatformAccessory', () => {
 
     resolveReadings!({
       actualHumidity: 48,
-      inletFilterDeterioration: 25,
-      outletFilterDeterioration: 100,
+      inletFilterReplacementInterval: 90,
+      inletFilterElapsedDays: 59,
+      outletFilterReplacementInterval: 90,
+      outletFilterElapsedDays: 100,
       currentDateTime: { second: 1, minute: 2, hour: 3, day: 4, weekDay: 5, month: 6, year: 26 },
       dhwTankTopTemperature: 51,
       outdoorTemperature: -5,

--- a/test/cts700Modbus.test.ts
+++ b/test/cts700Modbus.test.ts
@@ -136,6 +136,8 @@ describe('CTS700Modbus reads', () => {
         [Register.OutdoorTemperature, 0xffc9],
         [Register.PanelTemperature, 203],
         [Register.ActualHumidity, 48],
+        [Register.InletFilterDeterioration, 25],
+        [Register.OutletFilterDeterioration, 100],
         [Register.DHWTopTankTemperature, 521],
       ]);
       if (address === Register.CurrentTime) {
@@ -149,6 +151,8 @@ describe('CTS700Modbus reads', () => {
       outdoorTemperature: -5.5,
       panelTemperature: 20.3,
       actualHumidity: 48,
+      inletFilterDeterioration: 25,
+      outletFilterDeterioration: 100,
       dhwTankTopTemperature: 52.1,
       currentDateTime: {
         second: 30,
@@ -326,6 +330,8 @@ describe('CTS700Modbus writes', () => {
     await expect(modbus.writeFanSpeed(55.9)).resolves.toBe(55);
     await expect(modbus.writeRoomTemperatureSetPoint(21.5)).resolves.toBe(215);
     await expect(modbus.writeDHWSetPoint(52)).resolves.toBe(520);
+    await expect(modbus.resetInletFilter()).resolves.toBe(1);
+    await expect(modbus.resetOutletFilter()).resolves.toBe(1);
     await expect(modbus.writePauseOption(PauseOption.All)).resolves.toBe(PauseOption.All);
     await expect(modbus.writeVentilationMode(VentilationMode.Cooling)).resolves.toBe(VentilationMode.Cooling);
 
@@ -333,6 +339,8 @@ describe('CTS700Modbus writes', () => {
       [Register.FanSpeed, 55],
       [Register.RoomTemperatureSetPoint, 215],
       [Register.DHWTemperatureSetPoint, 520],
+      [Register.InletFilterReset, 1],
+      [Register.OutletFilterReset, 1],
       [Register.Pause, PauseOption.All],
       [Register.VentilationMode, VentilationMode.Cooling],
     ]);

--- a/test/cts700Modbus.test.ts
+++ b/test/cts700Modbus.test.ts
@@ -136,8 +136,10 @@ describe('CTS700Modbus reads', () => {
         [Register.OutdoorTemperature, 0xffc9],
         [Register.PanelTemperature, 203],
         [Register.ActualHumidity, 48],
-        [Register.InletFilterDeterioration, 25],
-        [Register.OutletFilterDeterioration, 100],
+        [Register.InletFilterReplacementInterval, 90],
+        [Register.InletFilterElapsedDays, 59],
+        [Register.OutletFilterReplacementInterval, 90],
+        [Register.OutletFilterElapsedDays, 90],
         [Register.DHWTopTankTemperature, 521],
       ]);
       if (address === Register.CurrentTime) {
@@ -151,8 +153,10 @@ describe('CTS700Modbus reads', () => {
       outdoorTemperature: -5.5,
       panelTemperature: 20.3,
       actualHumidity: 48,
-      inletFilterDeterioration: 25,
-      outletFilterDeterioration: 100,
+      inletFilterReplacementInterval: 90,
+      inletFilterElapsedDays: 59,
+      outletFilterReplacementInterval: 90,
+      outletFilterElapsedDays: 90,
       dhwTankTopTemperature: 52.1,
       currentDateTime: {
         second: 30,


### PR DESCRIPTION
## Summary

- expose the built-in CTS700 inlet and outlet filters as native HomeKit `FilterMaintenance` services
- calculate remaining filter life from the software-filter replacement interval and elapsed-day registers
- flag replacement at the configured interval and clamp overdue filters to 0% remaining
- support explicit HomeKit filter resets through the documented software-filter reset registers
- retain the existing built-in relative-humidity exposure on the ventilation thermostat
- document the expanded feature set

## Why

Software/time-based filter monitoring is the CTS700 default and is the mode used by the observed Compact P controller. The earlier implementation incorrectly used the hardware deterioration registers, which remain at 0% on software-mode units even while their elapsed-day counters advance.

At the observed 59/90-day state, HomeKit now reports 34% remaining instead of an incorrect 100%.

## Validation

- `npm run check`
- 3 test files and 35 tests pass
- statements: 85.42%
- branches: 72.56%
- functions: 89.52%
- lines: 85.57%
- read-only controller audit confirmed 59 elapsed days, a 90-day interval, and 0% hardware deterioration

All automated hardware interactions use a mocked Modbus client. No physical filter reset or other device write was performed.

Stacked on #16.
