### PR TITLE
Report effective CTS700 fan output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,9 @@ to real hardware.
   live writes without explicit user authorization and a known test device.
 - System working mode `AUTO` does not distinguish active schedule control from a
   temporary user override. User registers can change through HomeKit, the CTS700
-  UI, or another Modbus client. Treat inlet fan output as an inference signal,
-  not a target, because automatic controller functions may alter it.
+  UI, or another Modbus client. HomeKit fan speed reports inlet fan output as an
+  effective value; never infer target ownership from it because automatic
+  controller functions may alter it.
 - `npm run diagnose:cts700` is a read-only hardware observation tool. Keep real
   controller addresses and captured output out of commits.
 - `npm run audit:cts700` is a read-only settings inventory. It deliberately

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ For manual configuration, add an entry to the `platforms` array in Homebridge's
 | `devices` | Yes | One or more Compact P controller definitions. |
 | `devices[].name` | Yes | Display name for the HomeKit accessory. |
 | `devices[].host` | Yes | IPv4 address of the controller. |
-| `devices[].schedule` | No | Read automatic setpoints and fan speed from the CTS 700 week program; defaults to `true`. |
+| `devices[].schedule` | No | Read automatic temperature setpoints from the CTS 700 week program; defaults to `true`. |
 
 Give each configured device a unique IP address. If you change a device's
 `host`, Homebridge treats it as a new accessory because the IP address is part
@@ -131,13 +131,22 @@ of its persistent identity.
 
 Enable `schedule` when a week program is active on the controller. The plugin
 reads the active entry and never writes its values back to the user registers.
-The CTS 700 keeps scheduled and user targets separately: a change from HomeKit,
-the control-unit UI, or another Modbus client temporarily overrides the active
-schedule without leaving automatic working mode, and the next schedule entry
-resumes control. The plugin tracks those changes independently for fan, room,
-and hot-water targets. It uses the inlet fan output as a limited fan-only hint
-after startup or when the UI reapplies an unchanged value. Set the option to
-`false` if no week program is configured.
+The CTS 700 keeps scheduled and user temperature targets separately: a change
+from HomeKit, the control-unit UI, or another Modbus client temporarily
+overrides the active schedule without leaving automatic working mode, and the
+next schedule entry resumes control. The plugin tracks those changes
+independently for room and hot-water targets. Set the option to `false` if no
+week program is configured.
+
+HomeKit fan speed reports the controller's effective inlet-fan output rather
+than attempting to infer whether the schedule or user register selected it.
+Consequently, humidity control, cooling, balancing, and other automatic
+functions can move the displayed speed away from the value requested in
+HomeKit. A HomeKit speed change writes the user target once; a different
+read-back value never causes a retry. Turning the fan off uses the CTS 700
+ventilation-pause control and preserves the configured user target. The
+controller accepts running targets from 20% through 100%; HomeKit requests from
+1% through 19% are normalized to 20%, while 0% pauses ventilation.
 
 ## Troubleshooting
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -27,7 +27,7 @@
             "title": "Read week schedule",
             "type": "boolean",
             "default": true,
-            "description": "Enable this when a week schedule is programmed on the controller. The plugin reflects scheduled targets and temporary overrides from HomeKit or the control-unit UI without writing schedule values back to the controller."
+            "description": "Enable this when a week schedule is programmed on the controller. The plugin reflects scheduled temperature targets and temporary overrides from HomeKit or the control-unit UI without writing schedule values back to the controller. Fan speed always reports the controller's effective inlet-fan output."
           }
         }
       }

--- a/docs/cts700-diagnostics.md
+++ b/docs/cts700-diagnostics.md
@@ -71,10 +71,10 @@ schedule value to inlet-fan output register 4699. System working mode 1047
 remained `AUTO` before and after the transition. Consequently, working mode does
 not identify whether a scheduled or temporary user target is currently active.
 
-The plugin therefore treats changes to user registers as overrides whether they
-originate in HomeKit, the control-unit UI, or another Modbus client. Overrides
-remain active until the selected schedule record changes. For fan speed only,
-register 4699 can corroborate an override after restart or when the UI reapplies
-the existing register 4747 value. It is not treated as a target because automatic
-humidity, cooling, fan balancing, and other controller functions can modify the
-actual output.
+The plugin therefore treats changes to user temperature registers as overrides
+whether they originate in HomeKit, the control-unit UI, or another Modbus
+client. Temperature overrides remain active until the selected schedule record
+changes. Fan speed does not use this inference: HomeKit reports inlet-fan output
+register 4699 directly. Automatic humidity, cooling, balancing, and other
+controller functions can therefore change the displayed fan speed without
+causing additional writes to user target register 4747.

--- a/src/compactPAccessory.ts
+++ b/src/compactPAccessory.ts
@@ -93,14 +93,24 @@ export class CompactPPlatformAccessory {
     
     const c = platform.Characteristic;
     ventilationFanService.getCharacteristic(c.RotationSpeed).setProps({
-      minValue: 20,
+      minValue: 0,
       maxValue: 100,
-      minStep: 5,
+      minStep: 1,
     });
 
     ventilationFanService.getCharacteristic(c.RotationSpeed)
       .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-        this.handleTargetWrite('fanSpeed', next => this.cts700Modbus.writeFanSpeed(next), value as number, 'Rotation speed', callback);
+        const fanSpeed = value as number;
+        if (fanSpeed === 0) {
+          this.handleWrite(next => this.cts700Modbus.writeVentilationPaused(next), true, 'Ventilation pause', callback);
+          return;
+        }
+        this.handleWrite(
+          next => this.cts700Modbus.writeFanSpeed(next),
+          Math.max(20, fanSpeed),
+          'Rotation speed',
+          callback,
+        );
       });
 
     ventilationFanService.getCharacteristic(c.Active)
@@ -297,7 +307,6 @@ export class CompactPPlatformAccessory {
       this.platform.log.debug('Updating with settings:', settings);
 
       const userTargets: UserTargets = {
-        fanSpeed: settings.fanSpeed,
         roomTemperature: settings.roomTemperatureSetPoint,
         dhwTemperature: settings.dhwTemperatureSetPoint,
       };
@@ -317,7 +326,6 @@ export class CompactPPlatformAccessory {
         displayedTargets = this.targetResolver.resolveAutomaticTargets(
           userTargets,
           this.processedSchedule,
-          readings.inletFanControl,
         );
         this.platform.log.debug('Resolved automatic targets:', displayedTargets);
       } else {
@@ -364,7 +372,8 @@ export class CompactPPlatformAccessory {
         this.dhwThermostatService.updateCharacteristic(c.TargetHeatingCoolingState, c.TargetHeatingCoolingState.HEAT); 
       }
 
-      this.ventilationFanService.updateCharacteristic(c.RotationSpeed, displayedTargets.fanSpeed);
+      const ventilationPaused = settings.paused === PauseOption.Ventilation || settings.paused === PauseOption.All;
+      this.ventilationFanService.updateCharacteristic(c.RotationSpeed, ventilationPaused ? 0 : readings.inletFanControl);
       this.ventilationThermostatService.updateCharacteristic(c.TargetTemperature, displayedTargets.roomTemperature);
       this.dhwThermostatService.updateCharacteristic(c.TargetTemperature, displayedTargets.dhwTemperature);
     } catch (e) {

--- a/src/cts700Modbus.ts
+++ b/src/cts700Modbus.ts
@@ -341,6 +341,9 @@ export class CTS700Modbus {
   }
 
   public async writeFanSpeed(value: number): Promise<number> {
+    if (value < 20 || value > 100) {
+      throw Error('Value outside of acceptable range.');
+    }
     return this.writePercentageRegister(Register.FanSpeed, value);
   }
 

--- a/src/cts700TargetResolver.ts
+++ b/src/cts700TargetResolver.ts
@@ -3,7 +3,6 @@ import { isDeepStrictEqual } from 'node:util';
 import type { WeekScheduleRecord } from './cts700Data';
 
 export interface UserTargets {
-  fanSpeed: number;
   roomTemperature: number;
   dhwTemperature: number;
 }
@@ -19,7 +18,6 @@ export class CTS700TargetResolver {
   private previousSchedule: WeekScheduleRecord | null | undefined;
   private previousUserTargets?: UserTargets;
   private readonly userOverrides: Record<UserTarget, boolean> = {
-    fanSpeed: false,
     roomTemperature: false,
     dhwTemperature: false,
   };
@@ -41,7 +39,6 @@ export class CTS700TargetResolver {
   public resolveAutomaticTargets(
     userTargets: UserTargets,
     schedule: WeekScheduleRecord | null,
-    inletFanControl: number,
   ): ResolvedTargets {
     const scheduleChanged = this.previousSchedule !== undefined && !isDeepStrictEqual(schedule, this.previousSchedule);
     if (scheduleChanged) {
@@ -49,9 +46,6 @@ export class CTS700TargetResolver {
     }
 
     this.detectChangedUserTargets(userTargets);
-    if (!scheduleChanged) {
-      this.inferFanOverride(userTargets, schedule, inletFanControl);
-    }
 
     this.previousSchedule = schedule;
     this.previousUserTargets = { ...userTargets };
@@ -64,11 +58,9 @@ export class CTS700TargetResolver {
     }
 
     return {
-      fanSpeed: this.userOverrides.fanSpeed ? userTargets.fanSpeed : schedule.fanSpeed,
       roomTemperature: this.userOverrides.roomTemperature ? userTargets.roomTemperature : schedule.temperature,
       dhwTemperature: this.userOverrides.dhwTemperature ? userTargets.dhwTemperature : schedule.dhwTemperature,
       sources: {
-        fanSpeed: this.userOverrides.fanSpeed ? 'user' : 'schedule',
         roomTemperature: this.userOverrides.roomTemperature ? 'user' : 'schedule',
         dhwTemperature: this.userOverrides.dhwTemperature ? 'user' : 'schedule',
       },
@@ -87,18 +79,6 @@ export class CTS700TargetResolver {
     }
   }
 
-  private inferFanOverride(userTargets: UserTargets, schedule: WeekScheduleRecord | null, inletFanControl: number): void {
-    if (schedule === null || this.userOverrides.fanSpeed || userTargets.fanSpeed === schedule.fanSpeed) {
-      return;
-    }
-
-    const matchesUserTarget = Math.abs(inletFanControl - userTargets.fanSpeed) <= 1;
-    const matchesScheduleTarget = Math.abs(inletFanControl - schedule.fanSpeed) <= 1;
-    if (matchesUserTarget && !matchesScheduleTarget) {
-      this.userOverrides.fanSpeed = true;
-    }
-  }
-
   private clearUserOverrides(): void {
     for (const target of Object.keys(this.userOverrides) as UserTarget[]) {
       this.userOverrides[target] = false;
@@ -107,7 +87,6 @@ export class CTS700TargetResolver {
 
   private sources(source: TargetSource): Record<UserTarget, TargetSource> {
     return {
-      fanSpeed: source,
       roomTemperature: source,
       dhwTemperature: source,
     };

--- a/test/compactPAccessory.test.ts
+++ b/test/compactPAccessory.test.ts
@@ -194,6 +194,16 @@ describe('CompactPPlatformAccessory', () => {
     });
   });
 
+  it('supports the full effective fan-output range', () => {
+    const { Characteristic, services } = createHarness();
+
+    expect(services.get('compact-p-fan')!.getCharacteristic(Characteristic.RotationSpeed).props).toMatchObject({
+      minValue: 0,
+      maxValue: 100,
+      minStep: 1,
+    });
+  });
+
   it('polls readings and settings into HomeKit services', async () => {
     const { Characteristic, modbus, services } = createHarness();
 
@@ -259,7 +269,7 @@ describe('CompactPPlatformAccessory', () => {
     expect(services.get('compact-p-dhw')!.updates).toContainEqual([Characteristic.TargetTemperature, 50]);
   });
 
-  it('keeps an explicit HomeKit fan override while the active schedule record is unchanged', async () => {
+  it('reports effective fan output after a write without retrying the user target', async () => {
     const { Characteristic, modbus, services } = createHarness(true, { inletFanControl: 40 });
     modbus.fetchSettings.mockResolvedValue({
       dhwTemperatureSetPoint: 50,
@@ -282,10 +292,50 @@ describe('CompactPPlatformAccessory', () => {
 
     await vi.advanceTimersByTimeAsync(10000);
     await invokeSet(services.get('compact-p-fan')!, Characteristic.RotationSpeed, 60);
+    modbus.fetchReadings.mockResolvedValue({
+      ...await modbus.fetchReadings(),
+      inletFanControl: 63,
+    });
+    modbus.fetchReadings.mockClear();
     await vi.advanceTimersByTimeAsync(10000);
 
+    expect(modbus.writeFanSpeed).toHaveBeenCalledOnce();
     expect(modbus.writeFanSpeed).toHaveBeenCalledWith(60);
-    expect(services.get('compact-p-fan')!.updates.at(-1)).toEqual([Characteristic.RotationSpeed, 60]);
+    expect(services.get('compact-p-fan')!.updates.at(-1)).toEqual([Characteristic.RotationSpeed, 63]);
+  });
+
+  it('reports a ventilation pause as inactive with zero effective speed', async () => {
+    const { Characteristic, modbus, services } = createHarness(false, { inletFanControl: 60 });
+    modbus.fetchSettings.mockResolvedValue({
+      ...await modbus.fetchSettings(),
+      paused: PauseOption.Ventilation,
+    });
+    modbus.fetchSettings.mockClear();
+
+    await vi.advanceTimersByTimeAsync(10000);
+
+    expect(services.get('compact-p-fan')!.updates).toContainEqual([Characteristic.Active, Characteristic.Active.INACTIVE]);
+    expect(services.get('compact-p-fan')!.updates).toContainEqual([Characteristic.RotationSpeed, 0]);
+  });
+
+  it('maps a zero speed request to ventilation pause and clamps a running request to the controller minimum', async () => {
+    const { Characteristic, modbus, services } = createHarness();
+
+    await invokeSet(services.get('compact-p-fan')!, Characteristic.RotationSpeed, 0);
+    await invokeSet(services.get('compact-p-fan')!, Characteristic.RotationSpeed, 10);
+
+    expect(modbus.writeVentilationPaused).toHaveBeenCalledWith(true);
+    expect(modbus.writeFanSpeed).toHaveBeenCalledWith(20);
+  });
+
+  it('handles the separate active and speed writes sent when HomeKit starts the fan', async () => {
+    const { Characteristic, modbus, services } = createHarness();
+
+    await invokeSet(services.get('compact-p-fan')!, Characteristic.Active, Characteristic.Active.ACTIVE);
+    await invokeSet(services.get('compact-p-fan')!, Characteristic.RotationSpeed, 50);
+
+    expect(modbus.writeVentilationPaused).toHaveBeenCalledWith(false);
+    expect(modbus.writeFanSpeed).toHaveBeenCalledWith(50);
   });
 
   it('resets inlet and outlet filter counters from HomeKit', async () => {

--- a/test/cts700Modbus.test.ts
+++ b/test/cts700Modbus.test.ts
@@ -355,6 +355,7 @@ describe('CTS700Modbus writes', () => {
   });
 
   it.each([
+    ['low fan speed', () => createModbus().then((modbus) => modbus.writeFanSpeed(19))],
     ['fan speed', () => createModbus().then((modbus) => modbus.writeFanSpeed(101))],
     ['room temperature', () => createModbus().then((modbus) => modbus.writeRoomTemperatureSetPoint(4.5))],
     ['low DHW temperature', () => createModbus().then((modbus) => modbus.writeDHWSetPoint(9.5))],

--- a/test/cts700TargetResolver.test.ts
+++ b/test/cts700TargetResolver.test.ts
@@ -4,7 +4,6 @@ import type { WeekScheduleRecord } from '../src/cts700Data';
 import { CTS700TargetResolver, type UserTargets } from '../src/cts700TargetResolver';
 
 const userTargets: UserTargets = {
-  fanSpeed: 65,
   roomTemperature: 23,
   dhwTemperature: 48,
 };
@@ -20,15 +19,13 @@ const sundayNight: WeekScheduleRecord = {
 };
 
 describe('CTS700TargetResolver', () => {
-  it('uses schedule targets when the fan output confirms scheduled control', () => {
+  it('defaults ambiguous temperature targets to the schedule after startup', () => {
     const resolver = new CTS700TargetResolver();
 
-    expect(resolver.resolveAutomaticTargets(userTargets, sundayNight, 55)).toEqual({
-      fanSpeed: 55,
+    expect(resolver.resolveAutomaticTargets(userTargets, sundayNight)).toEqual({
       roomTemperature: 22,
       dhwTemperature: 50,
       sources: {
-        fanSpeed: 'schedule',
         roomTemperature: 'schedule',
         dhwTemperature: 'schedule',
       },
@@ -37,27 +34,22 @@ describe('CTS700TargetResolver', () => {
 
   it('keeps explicit HomeKit target overrides until the schedule record changes', () => {
     const resolver = new CTS700TargetResolver();
-    resolver.resolveAutomaticTargets(userTargets, sundayNight, 55);
-    resolver.markUserOverride('fanSpeed');
+    resolver.resolveAutomaticTargets(userTargets, sundayNight);
     resolver.markUserOverride('roomTemperature');
 
-    expect(resolver.resolveAutomaticTargets(userTargets, sundayNight, 65)).toMatchObject({
-      fanSpeed: 65,
+    expect(resolver.resolveAutomaticTargets(userTargets, sundayNight)).toMatchObject({
       roomTemperature: 23,
       dhwTemperature: 50,
       sources: {
-        fanSpeed: 'user',
         roomTemperature: 'user',
         dhwTemperature: 'schedule',
       },
     });
 
     const mondayMorning = { ...sundayNight, weekDay: 1, hour: 6, temperature: 21 };
-    expect(resolver.resolveAutomaticTargets(userTargets, mondayMorning, 65)).toMatchObject({
-      fanSpeed: 55,
+    expect(resolver.resolveAutomaticTargets(userTargets, mondayMorning)).toMatchObject({
       roomTemperature: 21,
       sources: {
-        fanSpeed: 'schedule',
         roomTemperature: 'schedule',
       },
     });
@@ -65,42 +57,15 @@ describe('CTS700TargetResolver', () => {
 
   it('detects independent user-register changes made by the CTS700 UI or another client', () => {
     const resolver = new CTS700TargetResolver();
-    resolver.resolveAutomaticTargets(userTargets, sundayNight, 55);
+    resolver.resolveAutomaticTargets(userTargets, sundayNight);
 
-    const changedTargets = { fanSpeed: 70, roomTemperature: 24, dhwTemperature: 52 };
-    expect(resolver.resolveAutomaticTargets(changedTargets, sundayNight, 55)).toMatchObject({
-      fanSpeed: 70,
+    const changedTargets = { roomTemperature: 24, dhwTemperature: 52 };
+    expect(resolver.resolveAutomaticTargets(changedTargets, sundayNight)).toMatchObject({
       roomTemperature: 24,
       dhwTemperature: 52,
       sources: {
-        fanSpeed: 'user',
         roomTemperature: 'user',
         dhwTemperature: 'user',
-      },
-    });
-  });
-
-  it('detects a same-value fan override from the observed inlet output', () => {
-    const resolver = new CTS700TargetResolver();
-    resolver.resolveAutomaticTargets(userTargets, sundayNight, 55);
-
-    expect(resolver.resolveAutomaticTargets(userTargets, sundayNight, 65)).toMatchObject({
-      fanSpeed: 65,
-      sources: { fanSpeed: 'user' },
-    });
-  });
-
-  it('uses fan output for restart inference but defaults ambiguous temperature targets to the schedule', () => {
-    const resolver = new CTS700TargetResolver();
-
-    expect(resolver.resolveAutomaticTargets(userTargets, sundayNight, 65)).toMatchObject({
-      fanSpeed: 65,
-      roomTemperature: 22,
-      dhwTemperature: 50,
-      sources: {
-        fanSpeed: 'user',
-        roomTemperature: 'schedule',
-        dhwTemperature: 'schedule',
       },
     });
   });
@@ -108,10 +73,9 @@ describe('CTS700TargetResolver', () => {
   it('falls back to user targets when there is no active schedule', () => {
     const resolver = new CTS700TargetResolver();
 
-    expect(resolver.resolveAutomaticTargets(userTargets, null, 65)).toEqual({
+    expect(resolver.resolveAutomaticTargets(userTargets, null)).toEqual({
       ...userTargets,
       sources: {
-        fanSpeed: 'user',
         roomTemperature: 'user',
         dhwTemperature: 'user',
       },


### PR DESCRIPTION
## Summary

- report CTS700 inlet-fan control output register 4699 as HomeKit `RotationSpeed`
- keep HomeKit speed writes directed to user target register 4747
- remove fan speed from schedule/user target inference while retaining room and DHW target resolution
- represent ventilation pause as inactive with zero effective speed
- support 0–100% output readback at 1% resolution; normalize running requests below the controller's 20% minimum
- document automatic humidity, cooling, and balancing behavior

## Why

The CTS700 does not expose which source currently owns the fan target. Register 4699 is an effective supply-fan control output, and automatic functions may alter it independently of schedule or user targets. Reporting that output directly is more truthful than inferring ownership and avoids long-lived false targets.

Register 4700 remains diagnostic-only because it is the extract-fan output and may differ due to balancing.

## Behavior

- schedule transitions and automatic controller adjustments appear on the next poll without fan-specific schedule state
- a HomeKit write is performed once even when subsequent output differs
- 0% pauses ventilation through register 4727
- requests from 1–19% normalize to the controller's 20% running minimum
- room and DHW temperatures continue using the read-only schedule resolver

## Validation

- `npm run check`
- 4 test files, 47 tests passed
- no live writes or successful live controller connection

Alternative to and supersedes #22. Stacked on #19.
