### PR TITLE
Recover recent temperature overrides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,10 @@ to real hardware.
   UI, or another Modbus client. HomeKit fan speed reports inlet fan output as an
   effective value; never infer target ownership from it because automatic
   controller functions may alter it.
+- Known room and DHW overrides are checkpointed in accessory context while
+  active. Restore them only within the documented short expiry when controller
+  time, the complete schedule record, and user targets validate unchanged. Keep
+  the snapshot versioned and discard malformed or ambiguous cache data.
 - `npm run diagnose:cts700` is a read-only hardware observation tool. Keep real
   controller addresses and captured output out of commits.
 - `npm run audit:cts700` is a read-only settings inventory. It deliberately

--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ next schedule entry resumes control. The plugin tracks those changes
 independently for room and hot-water targets. Set the option to `false` if no
 week program is configured.
 
+While a known room or hot-water override is active, the plugin checkpoints it
+in Homebridge's cached accessory context. A restart restores that state only
+when the controller time advanced by no more than 15 minutes and the complete
+active schedule record and user targets are unchanged. Expired, malformed, or
+ambiguous state is discarded in favor of the active schedule.
+
 HomeKit fan speed reports the controller's effective inlet-fan output rather
 than attempting to infer whether the schedule or user register selected it.
 Consequently, humidity control, cooling, balancing, and other automatic

--- a/src/compactPAccessory.ts
+++ b/src/compactPAccessory.ts
@@ -3,11 +3,18 @@ import { isDeepStrictEqual } from 'node:util';
 
 import { DateTime, OperationMode, PauseOption, SystemWorkingMode, VentilationMode, WeekScheduleRecord } from './cts700Data';
 import { CTS700Modbus } from './cts700Modbus';
-import { CTS700TargetResolver, UserTargets, UserTarget } from './cts700TargetResolver';
+import {
+  CTS700TargetResolver,
+  CTS700TargetResolverSnapshot,
+  UserTargets,
+  UserTarget,
+} from './cts700TargetResolver';
 import type { NilanHomebridgePlatform } from './platform';
 
 type WriterParameter = boolean | number | PauseOption | VentilationMode;
 type ModbusFactory = (host: string, didConnect: () => void) => CTS700Modbus;
+const RESOLVER_CHECKPOINT_INTERVAL_MS = 5 * 60 * 1000;
+const RESOLVER_CONTEXT_KEY = 'targetResolverState';
 
 export class CompactPPlatformAccessory {
   private ventilationFanService: Service;
@@ -25,6 +32,9 @@ export class CompactPPlatformAccessory {
   private processedDateTime?: DateTime;
   private processedSchedule: WeekScheduleRecord | null = null;
   private readonly targetResolver = new CTS700TargetResolver();
+  private resolverRestoreAttempted = false;
+  private lastControllerDateTime?: DateTime;
+  private lastResolverCheckpoint = 0;
 
   constructor(
     private readonly platform: NilanHomebridgePlatform,
@@ -67,6 +77,9 @@ export class CompactPPlatformAccessory {
   }
 
   public shutdown(): void {
+    if (this.lastControllerDateTime !== undefined) {
+      this.persistTargetResolverState(this.lastControllerDateTime, true);
+    }
     clearInterval(this.updateInterval);
     this.cts700Modbus.close();
   }
@@ -281,6 +294,7 @@ export class CompactPPlatformAccessory {
     this.updateInProgress = true;
     try {
       const readings = await this.cts700Modbus.fetchReadings();
+      this.lastControllerDateTime = { ...readings.currentDateTime };
       this.platform.log.debug('Updating with readings:', readings);
 
       const c = platform.Characteristic;
@@ -323,14 +337,27 @@ export class CompactPPlatformAccessory {
           this.processedDateTime = normalizedDateTime;
         }
 
+        if (!this.resolverRestoreAttempted) {
+          const restored = this.targetResolver.restoreSnapshot(
+            this.accessory.context[RESOLVER_CONTEXT_KEY],
+            readings.currentDateTime,
+            this.processedSchedule,
+            userTargets,
+          );
+          this.platform.log.debug(restored ? 'Restored recent temperature overrides.' : 'No recent temperature overrides restored.');
+          this.resolverRestoreAttempted = true;
+        }
+
         displayedTargets = this.targetResolver.resolveAutomaticTargets(
           userTargets,
           this.processedSchedule,
         );
         this.platform.log.debug('Resolved automatic targets:', displayedTargets);
       } else {
+        this.resolverRestoreAttempted = true;
         displayedTargets = this.targetResolver.useUserTargets(userTargets);
       }
+      this.persistTargetResolverState(readings.currentDateTime);
 
       if (settings.paused === PauseOption.Ventilation || settings.paused === PauseOption.All) {
         this.ventilationThermostatService.updateCharacteristic(c.CurrentHeatingCoolingState, c.CurrentHeatingCoolingState.OFF);
@@ -430,9 +457,42 @@ export class CompactPPlatformAccessory {
   ): Promise<number | null> {
     return this.handleWrite(writer, value, name, (error) => {
       if (error === null) {
-        this.targetResolver.markUserOverride(target);
+        this.targetResolver.markUserOverride(target, value);
       }
       callback(error);
     });
+  }
+
+  private persistTargetResolverState(currentTime: DateTime, force = false): void {
+    const snapshot = this.targetResolver.createSnapshot(currentTime);
+    const existing = this.accessory.context[RESOLVER_CONTEXT_KEY] as unknown;
+
+    if (snapshot === undefined) {
+      if (existing !== undefined) {
+        delete this.accessory.context[RESOLVER_CONTEXT_KEY];
+        this.platform.api.updatePlatformAccessories([this.accessory]);
+      }
+      return;
+    }
+
+    const checkpointDue = Date.now() - this.lastResolverCheckpoint >= RESOLVER_CHECKPOINT_INTERVAL_MS;
+    if (!force && !checkpointDue && this.sameResolverState(existing, snapshot)) {
+      return;
+    }
+
+    this.accessory.context[RESOLVER_CONTEXT_KEY] = snapshot;
+    this.lastResolverCheckpoint = Date.now();
+    this.platform.api.updatePlatformAccessories([this.accessory]);
+  }
+
+  private sameResolverState(existing: unknown, snapshot: CTS700TargetResolverSnapshot): boolean {
+    if (typeof existing !== 'object' || existing === null) {
+      return false;
+    }
+    const existingState = { ...existing as CTS700TargetResolverSnapshot };
+    const snapshotState = { ...snapshot };
+    delete (existingState as Partial<CTS700TargetResolverSnapshot>).savedAt;
+    delete (snapshotState as Partial<CTS700TargetResolverSnapshot>).savedAt;
+    return isDeepStrictEqual(existingState, snapshotState);
   }
 }

--- a/src/cts700TargetResolver.ts
+++ b/src/cts700TargetResolver.ts
@@ -1,6 +1,9 @@
 import { isDeepStrictEqual } from 'node:util';
 
-import type { WeekScheduleRecord } from './cts700Data';
+import type { DateTime, WeekScheduleRecord } from './cts700Data';
+
+const SNAPSHOT_VERSION = 1;
+const SNAPSHOT_MAX_AGE_MS = 15 * 60 * 1000;
 
 export interface UserTargets {
   roomTemperature: number;
@@ -14,6 +17,14 @@ export interface ResolvedTargets extends UserTargets {
   sources: Record<UserTarget, TargetSource>;
 }
 
+export interface CTS700TargetResolverSnapshot {
+  version: typeof SNAPSHOT_VERSION;
+  savedAt: DateTime;
+  schedule: WeekScheduleRecord;
+  userTargets: UserTargets;
+  userOverrides: Record<UserTarget, boolean>;
+}
+
 export class CTS700TargetResolver {
   private previousSchedule: WeekScheduleRecord | null | undefined;
   private previousUserTargets?: UserTargets;
@@ -22,8 +33,50 @@ export class CTS700TargetResolver {
     dhwTemperature: false,
   };
 
-  public markUserOverride(target: UserTarget): void {
+  public markUserOverride(target: UserTarget, value: number): void {
     this.userOverrides[target] = true;
+    if (this.previousUserTargets !== undefined) {
+      this.previousUserTargets[target] = value;
+    }
+  }
+
+  public createSnapshot(savedAt: DateTime): CTS700TargetResolverSnapshot | undefined {
+    if (this.previousSchedule === undefined || this.previousSchedule === null || this.previousUserTargets === undefined ||
+      !Object.values(this.userOverrides).some(Boolean)) {
+      return undefined;
+    }
+
+    return {
+      version: SNAPSHOT_VERSION,
+      savedAt: { ...savedAt },
+      schedule: { ...this.previousSchedule },
+      userTargets: { ...this.previousUserTargets },
+      userOverrides: { ...this.userOverrides },
+    };
+  }
+
+  public restoreSnapshot(
+    value: unknown,
+    currentTime: DateTime,
+    currentSchedule: WeekScheduleRecord | null,
+    currentUserTargets: UserTargets,
+  ): boolean {
+    if (!this.isSnapshot(value) || currentSchedule === null || !isDeepStrictEqual(value.schedule, currentSchedule) ||
+      !isDeepStrictEqual(value.userTargets, currentUserTargets)) {
+      return false;
+    }
+
+    const savedAt = this.dateTimeMilliseconds(value.savedAt);
+    const now = this.dateTimeMilliseconds(currentTime);
+    const age = now - savedAt;
+    if (!Number.isFinite(age) || age < 0 || age > SNAPSHOT_MAX_AGE_MS) {
+      return false;
+    }
+
+    this.previousSchedule = { ...currentSchedule };
+    this.previousUserTargets = { ...currentUserTargets };
+    Object.assign(this.userOverrides, value.userOverrides);
+    return true;
   }
 
   public useUserTargets(userTargets: UserTargets): ResolvedTargets {
@@ -90,5 +143,78 @@ export class CTS700TargetResolver {
       roomTemperature: source,
       dhwTemperature: source,
     };
+  }
+
+  private isSnapshot(value: unknown): value is CTS700TargetResolverSnapshot {
+    if (typeof value !== 'object' || value === null) {
+      return false;
+    }
+
+    const snapshot = value as Partial<CTS700TargetResolverSnapshot>;
+    return snapshot.version === SNAPSHOT_VERSION &&
+      this.isDateTime(snapshot.savedAt) &&
+      this.isSchedule(snapshot.schedule) &&
+      this.isUserTargets(snapshot.userTargets) &&
+      this.isUserOverrides(snapshot.userOverrides) &&
+      Object.values(snapshot.userOverrides).some(Boolean);
+  }
+
+  private isDateTime(value: unknown): value is DateTime {
+    if (typeof value !== 'object' || value === null) {
+      return false;
+    }
+    const dateTime = value as Partial<DateTime>;
+    return this.isIntegerInRange(dateTime.second, 0, 59) &&
+      this.isIntegerInRange(dateTime.minute, 0, 59) &&
+      this.isIntegerInRange(dateTime.hour, 0, 23) &&
+      this.isIntegerInRange(dateTime.day, 1, 31) &&
+      this.isIntegerInRange(dateTime.weekDay, 1, 7) &&
+      this.isIntegerInRange(dateTime.month, 1, 12) &&
+      this.isIntegerInRange(dateTime.year, 0, 38);
+  }
+
+  private isSchedule(value: unknown): value is WeekScheduleRecord {
+    if (typeof value !== 'object' || value === null) {
+      return false;
+    }
+    const schedule = value as Partial<WeekScheduleRecord>;
+    return this.isIntegerInRange(schedule.weekDay, 1, 7) &&
+      this.isIntegerInRange(schedule.hour, 0, 23) &&
+      this.isIntegerInRange(schedule.minute, 0, 59) &&
+      typeof schedule.temperature === 'number' && schedule.temperature >= 5 && schedule.temperature <= 50 &&
+      typeof schedule.dhwTemperature === 'number' && schedule.dhwTemperature >= 10 && schedule.dhwTemperature <= 60 &&
+      this.isIntegerInRange(schedule.flags, -128, 255) &&
+      this.isIntegerInRange(schedule.fanSpeed, 0, 100);
+  }
+
+  private isUserTargets(value: unknown): value is UserTargets {
+    if (typeof value !== 'object' || value === null) {
+      return false;
+    }
+    const targets = value as Partial<UserTargets>;
+    return typeof targets.roomTemperature === 'number' && targets.roomTemperature >= 5 && targets.roomTemperature <= 50 &&
+      typeof targets.dhwTemperature === 'number' && targets.dhwTemperature >= 10 && targets.dhwTemperature <= 65;
+  }
+
+  private isUserOverrides(value: unknown): value is Record<UserTarget, boolean> {
+    if (typeof value !== 'object' || value === null) {
+      return false;
+    }
+    const overrides = value as Partial<Record<UserTarget, boolean>>;
+    return typeof overrides.roomTemperature === 'boolean' && typeof overrides.dhwTemperature === 'boolean';
+  }
+
+  private isIntegerInRange(value: unknown, minimum: number, maximum: number): value is number {
+    return typeof value === 'number' && Number.isInteger(value) && value >= minimum && value <= maximum;
+  }
+
+  private dateTimeMilliseconds(value: DateTime): number {
+    const milliseconds = Date.UTC(2000 + value.year, value.month - 1, value.day, value.hour, value.minute, value.second);
+    const normalized = new Date(milliseconds);
+    if (normalized.getUTCFullYear() !== 2000 + value.year || normalized.getUTCMonth() !== value.month - 1 ||
+      normalized.getUTCDate() !== value.day) {
+      return Number.NaN;
+    }
+    return milliseconds;
   }
 }

--- a/test/compactPAccessory.test.ts
+++ b/test/compactPAccessory.test.ts
@@ -53,7 +53,7 @@ class FakeService {
   }
 }
 
-function createHarness(schedule = false, readingOverrides: Partial<Readings> = {}) {
+function createHarness(schedule = false, readingOverrides: Partial<Readings> = {}, contextOverrides: Record<string, unknown> = {}) {
   const Characteristic = {
     Active: Object.assign(Symbol('Active'), { ACTIVE: 1, INACTIVE: 0 }),
     CurrentHeatingCoolingState: Object.assign(Symbol('CurrentHeatingCoolingState'), { COOL: 2, HEAT: 1, OFF: 0 }),
@@ -86,11 +86,14 @@ function createHarness(schedule = false, readingOverrides: Partial<Readings> = {
       services.set(subtype, service);
       return service;
     }),
-    context: { device: { host: '192.0.2.1', schedule } },
+    context: { device: { host: '192.0.2.1', schedule }, ...contextOverrides },
     getService: vi.fn(() => informationService),
     getServiceById: vi.fn((_type: unknown, subtype: string) => services.get(subtype)),
   };
   const platform = {
+    api: {
+      updatePlatformAccessories: vi.fn(),
+    },
     Characteristic,
     Service: ServiceTypes,
     log: {
@@ -336,6 +339,66 @@ describe('CompactPPlatformAccessory', () => {
 
     expect(modbus.writeVentilationPaused).toHaveBeenCalledWith(false);
     expect(modbus.writeFanSpeed).toHaveBeenCalledWith(50);
+  });
+
+  it('persists and restores a recent room-temperature override', async () => {
+    const first = createHarness(true);
+    first.modbus.fetchSettings.mockResolvedValue({
+      ...await first.modbus.fetchSettings(),
+      systemWorkingMode: SystemWorkingMode.Auto,
+    });
+    first.modbus.fetchSettings.mockClear();
+    first.modbus.fetchActiveWeekProgramForDateTime.mockResolvedValue({
+      dhwTemperature: 48,
+      fanSpeed: 40,
+      flags: 0,
+      hour: 3,
+      minute: 0,
+      temperature: 20,
+      weekDay: 5,
+    });
+
+    await vi.advanceTimersByTimeAsync(10000);
+    await invokeSet(first.services.get('compact-p-temperature')!, first.Characteristic.TargetTemperature, 23);
+    first.modbus.fetchSettings.mockResolvedValue({
+      ...await first.modbus.fetchSettings(),
+      roomTemperatureSetPoint: 23,
+    });
+    first.modbus.fetchSettings.mockClear();
+    await vi.advanceTimersByTimeAsync(10000);
+
+    const snapshot = first.accessory.context.targetResolverState;
+    expect(snapshot).toBeDefined();
+    expect(first.platform.api.updatePlatformAccessories).toHaveBeenCalled();
+    first.handler.shutdown();
+
+    const restored = createHarness(
+      true,
+      { currentDateTime: { second: 1, minute: 3, hour: 3, day: 4, weekDay: 5, month: 6, year: 26 } },
+      { targetResolverState: snapshot },
+    );
+    restored.modbus.fetchSettings.mockResolvedValue({
+      ...await restored.modbus.fetchSettings(),
+      roomTemperatureSetPoint: 23,
+      systemWorkingMode: SystemWorkingMode.Auto,
+    });
+    restored.modbus.fetchSettings.mockClear();
+    restored.modbus.fetchActiveWeekProgramForDateTime.mockResolvedValue({
+      dhwTemperature: 48,
+      fanSpeed: 40,
+      flags: 0,
+      hour: 3,
+      minute: 0,
+      temperature: 20,
+      weekDay: 5,
+    });
+
+    await vi.advanceTimersByTimeAsync(10000);
+
+    expect(restored.services.get('compact-p-temperature')!.updates.at(-1)).toEqual([
+      restored.Characteristic.TargetTemperature,
+      23,
+    ]);
   });
 
   it('resets inlet and outlet filter counters from HomeKit', async () => {

--- a/test/cts700TargetResolver.test.ts
+++ b/test/cts700TargetResolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { WeekScheduleRecord } from '../src/cts700Data';
+import type { DateTime, WeekScheduleRecord } from '../src/cts700Data';
 import { CTS700TargetResolver, type UserTargets } from '../src/cts700TargetResolver';
 
 const userTargets: UserTargets = {
@@ -16,6 +16,16 @@ const sundayNight: WeekScheduleRecord = {
   dhwTemperature: 50,
   flags: 0,
   fanSpeed: 55,
+};
+
+const controllerTime: DateTime = {
+  second: 0,
+  minute: 5,
+  hour: 23,
+  day: 16,
+  weekDay: 7,
+  month: 8,
+  year: 26,
 };
 
 describe('CTS700TargetResolver', () => {
@@ -35,7 +45,7 @@ describe('CTS700TargetResolver', () => {
   it('keeps explicit HomeKit target overrides until the schedule record changes', () => {
     const resolver = new CTS700TargetResolver();
     resolver.resolveAutomaticTargets(userTargets, sundayNight);
-    resolver.markUserOverride('roomTemperature');
+    resolver.markUserOverride('roomTemperature', 23);
 
     expect(resolver.resolveAutomaticTargets(userTargets, sundayNight)).toMatchObject({
       roomTemperature: 23,
@@ -53,6 +63,7 @@ describe('CTS700TargetResolver', () => {
         roomTemperature: 'schedule',
       },
     });
+    expect(resolver.createSnapshot(controllerTime)).toBeUndefined();
   });
 
   it('detects independent user-register changes made by the CTS700 UI or another client', () => {
@@ -80,5 +91,56 @@ describe('CTS700TargetResolver', () => {
         dhwTemperature: 'user',
       },
     });
+  });
+
+  it('restores a recent known override when schedule and user targets are unchanged', () => {
+    const original = new CTS700TargetResolver();
+    original.resolveAutomaticTargets(userTargets, sundayNight);
+    original.markUserOverride('roomTemperature', 23);
+    const snapshot = original.createSnapshot(controllerTime);
+
+    const restored = new CTS700TargetResolver();
+    const fiveMinutesLater = { ...controllerTime, minute: 10 };
+    expect(restored.restoreSnapshot(snapshot, fiveMinutesLater, sundayNight, userTargets)).toBe(true);
+    expect(restored.resolveAutomaticTargets(userTargets, sundayNight)).toMatchObject({
+      roomTemperature: 23,
+      dhwTemperature: 50,
+      sources: {
+        roomTemperature: 'user',
+        dhwTemperature: 'schedule',
+      },
+    });
+  });
+
+  it('rejects stale, changed, or malformed snapshots', () => {
+    const original = new CTS700TargetResolver();
+    original.resolveAutomaticTargets(userTargets, sundayNight);
+    original.markUserOverride('roomTemperature', 23);
+    const snapshot = original.createSnapshot(controllerTime);
+    const changedSchedule = { ...sundayNight, hour: 22 };
+    const changedTargets = { ...userTargets, roomTemperature: 24 };
+
+    expect(new CTS700TargetResolver().restoreSnapshot(
+      snapshot,
+      { ...controllerTime, minute: 21 },
+      sundayNight,
+      userTargets,
+    )).toBe(false);
+    expect(new CTS700TargetResolver().restoreSnapshot(snapshot, controllerTime, changedSchedule, userTargets)).toBe(false);
+    expect(new CTS700TargetResolver().restoreSnapshot(snapshot, controllerTime, sundayNight, changedTargets)).toBe(false);
+    expect(new CTS700TargetResolver().restoreSnapshot({ version: 1 }, controllerTime, sundayNight, userTargets)).toBe(false);
+    expect(new CTS700TargetResolver().restoreSnapshot(
+      { ...snapshot!, userOverrides: { roomTemperature: false, dhwTemperature: false } },
+      controllerTime,
+      sundayNight,
+      userTargets,
+    )).toBe(false);
+  });
+
+  it('does not create persisted state without an active override', () => {
+    const resolver = new CTS700TargetResolver();
+    resolver.resolveAutomaticTargets(userTargets, sundayNight);
+
+    expect(resolver.createSnapshot(controllerTime)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- checkpoint known room and DHW overrides in Homebridge accessory context
- restore them after a short restart only when controller time, the full schedule record, and user targets remain consistent
- expire snapshots after 15 controller minutes
- refresh active snapshots at five-minute intervals and on shutdown
- version and validate all cached data before use

## Recovery policy

A snapshot is restored only when:

- at least one room or DHW override was known to Homebridge
- the snapshot is structurally valid and all values are within protocol ranges
- controller time moved forward by no more than 15 minutes
- the complete active schedule record is unchanged
- both user temperature registers are unchanged
- schedule handling remains enabled and the controller remains in automatic mode

Any failed check discards the snapshot and uses the active schedule. Fan speed is intentionally excluded because the lower PR reports effective inlet-fan output directly.

## Validation

- `npm run check`
- 4 test files, 51 tests passed
- simulated accessory-cache restart verifies restoration
- tests reject expired, changed, empty, and malformed snapshots
- no live controller calls or writes

Stacked on #23, which is stacked on #19.
