### PR TITLE
Keep polling when filter counters are invalid

### DIFF
--- a/src/compactPAccessory.ts
+++ b/src/compactPAccessory.ts
@@ -35,6 +35,7 @@ export class CompactPPlatformAccessory {
   private resolverRestoreAttempted = false;
   private lastControllerDateTime?: DateTime;
   private lastResolverCheckpoint = 0;
+  private invalidFilterReadingsLogged = false;
 
   constructor(
     private readonly platform: NilanHomebridgePlatform,
@@ -304,18 +305,27 @@ export class CompactPPlatformAccessory {
       this.panelTemperatureSensorService.updateCharacteristic(c.CurrentTemperature, readings.panelTemperature);
       this.ventilationThermostatService.updateCharacteristic(c.CurrentRelativeHumidity, readings.actualHumidity);
       this.dhwThermostatService.updateCharacteristic(c.CurrentTemperature, readings.dhwTankTopTemperature);
-      this.updateFilterMaintenance(
+      const inletFilterUpdated = this.updateFilterMaintenance(
         this.inletFilterMaintenanceService,
         readings.inletFilterElapsedDays,
         readings.inletFilterReplacementInterval,
         c,
       );
-      this.updateFilterMaintenance(
+      const outletFilterUpdated = this.updateFilterMaintenance(
         this.outletFilterMaintenanceService,
         readings.outletFilterElapsedDays,
         readings.outletFilterReplacementInterval,
         c,
       );
+      if (!inletFilterUpdated || !outletFilterUpdated) {
+        if (!this.invalidFilterReadingsLogged) {
+          this.platform.log.warn('Filter counters are outside the supported time-based range; leaving filter state unchanged.');
+          this.invalidFilterReadingsLogged = true;
+        }
+      } else if (this.invalidFilterReadingsLogged) {
+        this.platform.log.info('Filter counters returned to the supported time-based range.');
+        this.invalidFilterReadingsLogged = false;
+      }
 
       const settings = await this.cts700Modbus.fetchSettings();
       this.platform.log.debug('Updating with settings:', settings);
@@ -412,10 +422,13 @@ export class CompactPPlatformAccessory {
 
   private updateFilterMaintenance(
     service: Service,
-    elapsedDays: number,
-    replacementInterval: number,
+    elapsedDays: number | null,
+    replacementInterval: number | null,
     c: NilanHomebridgePlatform['Characteristic'],
-  ): void {
+  ): boolean {
+    if (elapsedDays === null || replacementInterval === null) {
+      return false;
+    }
     const remainingDays = Math.max(0, replacementInterval - elapsedDays);
     const filterLifeLevel = Math.round(remainingDays / replacementInterval * 100);
     const changeIndication = elapsedDays >= replacementInterval
@@ -423,6 +436,7 @@ export class CompactPPlatformAccessory {
       : c.FilterChangeIndication.FILTER_OK;
     service.updateCharacteristic(c.FilterLifeLevel, filterLifeLevel);
     service.updateCharacteristic(c.FilterChangeIndication, changeIndication);
+    return true;
   }
 
   private async handleWrite<T extends WriterParameter, R extends WriterParameter>(

--- a/src/cts700Data.ts
+++ b/src/cts700Data.ts
@@ -160,10 +160,10 @@ export interface Readings {
 	// Current inlet-fan control output (0-100%).
 	inletFanControl: number;
 	// Software filter replacement intervals and elapsed times in days.
-	inletFilterReplacementInterval: number;
-	inletFilterElapsedDays: number;
-	outletFilterReplacementInterval: number;
-	outletFilterElapsedDays: number;
+	inletFilterReplacementInterval: number | null;
+	inletFilterElapsedDays: number | null;
+	outletFilterReplacementInterval: number | null;
+	outletFilterElapsedDays: number | null;
 	// DHW tank top temperature in C times 10
 	dhwTankTopTemperature: number;
 	// Current device time.

--- a/src/cts700Modbus.ts
+++ b/src/cts700Modbus.ts
@@ -183,21 +183,21 @@ export class CTS700Modbus {
       });
   }
 
-  private async readFilterReplacementInterval(register: Register): Promise<number> {
+  private async readFilterReplacementInterval(register: Register): Promise<number | null> {
     return this.readSingleRegister(register)
       .then((result) => {
         if (result < 30 || result > 360) {
-          throw Error('Filter replacement interval outside of acceptable range.');
+          return null;
         }
         return result;
       });
   }
 
-  private async readFilterElapsedDays(register: Register): Promise<number> {
+  private async readFilterElapsedDays(register: Register): Promise<number | null> {
     return this.readSingleRegister(register)
       .then((result) => {
         if (result > 360) {
-          throw Error('Filter elapsed time outside of acceptable range.');
+          return null;
         }
         return result;
       });

--- a/test/compactPAccessory.test.ts
+++ b/test/compactPAccessory.test.ts
@@ -99,6 +99,8 @@ function createHarness(schedule = false, readingOverrides: Partial<Readings> = {
     log: {
       debug: vi.fn(),
       error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
     },
   };
   const modbus = {
@@ -430,6 +432,21 @@ describe('CompactPPlatformAccessory', () => {
       Characteristic.FilterChangeIndication,
       Characteristic.FilterChangeIndication.CHANGE_FILTER,
     ]);
+  });
+
+  it('continues updating other characteristics when filter counters are unavailable', async () => {
+    const { Characteristic, platform, services } = createHarness(false, {
+      inletFilterReplacementInterval: null,
+      outletFilterElapsedDays: null,
+      roomTemperature: 23,
+    });
+
+    await vi.advanceTimersByTimeAsync(20000);
+
+    expect(services.get('compact-p-temperature')!.updates).toContainEqual([Characteristic.CurrentTemperature, 23]);
+    expect(services.get('compact-p-inlet-filter')!.updates)
+      .not.toContainEqual(expect.arrayContaining([Characteristic.FilterLifeLevel]));
+    expect(platform.log.warn).toHaveBeenCalledOnce();
   });
 
   it('does not overlap slow polling cycles', async () => {

--- a/test/cts700Modbus.test.ts
+++ b/test/cts700Modbus.test.ts
@@ -172,6 +172,37 @@ describe('CTS700Modbus reads', () => {
     });
   });
 
+  it('keeps non-filter readings available when time-based filter counters are invalid', async () => {
+    const modbus = await createModbus();
+    client.readHoldingRegisters.mockImplementation(async (address: number) => {
+      const values = new Map<number, number>([
+        [Register.MasterSensorTemperature, 215],
+        [Register.OutdoorTemperature, 100],
+        [Register.PanelTemperature, 203],
+        [Register.ActualHumidity, 48],
+        [Register.InletFanControl, 55],
+        [Register.InletFilterReplacementInterval, 0],
+        [Register.InletFilterElapsedDays, 59],
+        [Register.OutletFilterReplacementInterval, 90],
+        [Register.OutletFilterElapsedDays, 400],
+        [Register.DHWTopTankTemperature, 521],
+      ]);
+      if (address === Register.CurrentTime) {
+        return registerResult([0x1e2d, 0x0e10, 0x0708, 0x1a00]);
+      }
+      return registerResult([values.get(address)!]);
+    });
+
+    await expect(modbus.fetchReadings()).resolves.toMatchObject({
+      roomTemperature: 21.5,
+      actualHumidity: 48,
+      inletFilterReplacementInterval: null,
+      inletFilterElapsedDays: 59,
+      outletFilterReplacementInterval: 90,
+      outletFilterElapsedDays: null,
+    });
+  });
+
   it('validates and decodes settings', async () => {
     const modbus = await createModbus();
     const values = new Map<number, number>([


### PR DESCRIPTION
## Summary

- treat out-of-range software filter counters as unavailable instead of failing the complete controller poll
- continue updating temperatures, humidity, fan output, pause state, and targets
- leave only the affected filter state unchanged and log the anomaly once until readings recover
- preserve network-error propagation and reconnect behavior

## Validation

- added protocol coverage for zero replacement interval and excessive elapsed days
- added accessory coverage proving temperature updates continue and warnings are throttled
- `npm run check`: 59 tests pass

No hardware writes or live controller access were performed.
