### PR TITLE
Serialize shared pause register writes

### DIFF
--- a/src/cts700Modbus.ts
+++ b/src/cts700Modbus.ts
@@ -18,6 +18,7 @@ export class CTS700Modbus {
   private client: ModbusRTU | null = null;
   private reconnectTimer?: ReturnType<typeof setTimeout>;
   private disposed = false;
+  private pauseWriteQueue: Promise<void> = Promise.resolve();
 
   private networkErrors = [
     'ESOCKETTIMEDOUT',
@@ -405,10 +406,14 @@ export class CTS700Modbus {
     return this.writeSingleRegister(register, modbusValue);
   }
 
-  private async writePauseComponent(component: PauseOption, paused: boolean): Promise<PauseOption> {
-    const current = await this.readPauseRegister(Register.Pause);
-    const updated = paused ? current | component : current & ~component;
-    return this.writePauseOption(updated as PauseOption);
+  private writePauseComponent(component: PauseOption, paused: boolean): Promise<PauseOption> {
+    const operation = this.pauseWriteQueue.then(async () => {
+      const current = await this.readPauseRegister(Register.Pause);
+      const updated = paused ? current | component : current & ~component;
+      return this.writePauseOption(updated as PauseOption);
+    });
+    this.pauseWriteQueue = operation.then(() => undefined, () => undefined);
+    return operation;
   }
 
   private async writeSingleRegister(register: Register, value: number): Promise<number> {

--- a/test/cts700Modbus.test.ts
+++ b/test/cts700Modbus.test.ts
@@ -427,4 +427,39 @@ describe('CTS700Modbus writes', () => {
     await expect(modbus.writeDHWPaused(false)).resolves.toBe(PauseOption.Ventilation);
     expect(client.writeRegister).toHaveBeenLastCalledWith(Register.Pause, PauseOption.Ventilation);
   });
+
+  it('serializes concurrent changes to the shared pause register', async () => {
+    const modbus = await createModbus();
+    let pause = PauseOption.Disabled;
+    client.readHoldingRegisters.mockImplementation(async () => registerResult([pause]));
+    client.writeRegister.mockImplementation(async (address: number, value: PauseOption) => {
+      pause = value;
+      return { address, value };
+    });
+
+    await Promise.all([
+      modbus.writeVentilationPaused(true),
+      modbus.writeDHWPaused(true),
+    ]);
+
+    expect(pause).toBe(PauseOption.All);
+    expect(client.writeRegister.mock.calls).toEqual([
+      [Register.Pause, PauseOption.Ventilation],
+      [Register.Pause, PauseOption.All],
+    ]);
+  });
+
+  it('continues the pause queue after a failed mutation', async () => {
+    const modbus = await createModbus();
+    client.readHoldingRegisters.mockResolvedValue(registerResult([PauseOption.Disabled]));
+    client.writeRegister
+      .mockRejectedValueOnce(new Error('write failed'))
+      .mockResolvedValueOnce({ address: Register.Pause, value: PauseOption.DHW });
+
+    const first = modbus.writeVentilationPaused(true);
+    const second = modbus.writeDHWPaused(true);
+
+    await expect(first).rejects.toThrow('write failed');
+    await expect(second).resolves.toBe(PauseOption.DHW);
+  });
 });


### PR DESCRIPTION
## Summary

- serialize read-modify-write operations on the CTS700 pause register
- preserve both ventilation and DHW bits when HomeKit sends the two changes concurrently
- keep the queue usable after a failed device write

## Validation

- added a concurrent-write regression test that finishes with both pause bits set
- added a failure-recovery test for the queue
- `npm run check`: 61 tests pass

No hardware writes or live controller access were performed.
