### PR TITLE
Harden releases and package contents

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,14 @@ updates:
     groups:
       production-dependencies:
         dependency-type: production
+        update-types:
+          - minor
+          - patch
       development-dependencies:
         dependency-type: development
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           node -e "const packageJson = require('./package.json'); const expected = 'v' + packageJson.version; if (process.env.RELEASE_TAG !== expected) { throw new Error('Release tag ' + process.env.RELEASE_TAG + ' must match package version ' + expected); }"
           git merge-base --is-ancestor HEAD origin/master
-          node -e "const [major, minor] = process.argv[1].split('.').map(Number); if (major < 11 || (major === 11 && minor < 5)) { throw new Error('npm 11.5.1 or newer is required for trusted publishing'); }" "$(npm --version)"
+          node -e "const [major, minor, patch] = process.argv[1].split('.').map(Number); if (major < 11 || (major === 11 && (minor < 5 || (minor === 5 && patch < 1)))) { throw new Error('npm 11.5.1 or newer is required for trusted publishing'); }" "$(npm --version)"
 
       - name: Install dependencies
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="left">
   <a href="https://homebridge.io"><img src="https://raw.githubusercontent.com/homebridge/branding/latest/logos/homebridge-color-round.png" height="70" alt="Homebridge logo"></a>
   &nbsp;
-  <a href="https://www.nilan.dk"><img src="resources/images/nilan-logo.png" height="70" alt="Nilan logo"></a>
+  <a href="https://www.nilan.dk"><img src="https://raw.githubusercontent.com/matej/homebridge-nilan/master/resources/images/nilan-logo.png" height="70" alt="Nilan logo"></a>
 </p>
 
 # Homebridge Nilan
@@ -35,11 +35,11 @@ polls the controller every 10 seconds.
 
 ### Apple Home
 
-<img src="resources/screenshots/1.png" height="300" alt="Screenshot Apple Home App"> <img src="resources/screenshots/2.png" height="300" alt="Screenshot Apple Home App"> <img src="resources/screenshots/3.png" height="300" alt="Screenshot Apple Home App"> 
+<img src="https://raw.githubusercontent.com/matej/homebridge-nilan/master/resources/screenshots/1.png" height="300" alt="Screenshot Apple Home App"> <img src="https://raw.githubusercontent.com/matej/homebridge-nilan/master/resources/screenshots/2.png" height="300" alt="Screenshot Apple Home App"> <img src="https://raw.githubusercontent.com/matej/homebridge-nilan/master/resources/screenshots/3.png" height="300" alt="Screenshot Apple Home App">
 
 ### Eve
 
-<img src="resources/screenshots/4.png" height="300" alt="Screenshot Elgato Eve App"> <img src="resources/screenshots/5.png" height="300" alt="Screenshot Elgato Eve App">
+<img src="https://raw.githubusercontent.com/matej/homebridge-nilan/master/resources/screenshots/4.png" height="300" alt="Screenshot Elgato Eve App"> <img src="https://raw.githubusercontent.com/matej/homebridge-nilan/master/resources/screenshots/5.png" height="300" alt="Screenshot Elgato Eve App">
 
 ## Supported Devices
 
@@ -51,7 +51,7 @@ implementation follows Nilan's *CTS 700 Modbus Registers Description*, revision
 2.01 (last updated 2016-03-11). Nilan no longer hosts it at its original URL, but
 a [preserved copy is available from the Internet Archive](https://web.archive.org/web/20250204012946id_/https://symlink.dk/stuff/CTS700_MODBUS-rev%202.01.pdf).
 
-<img src="resources/images/nilan-compact-p.png" height="200" alt="Nilan Compact P">
+<img src="https://raw.githubusercontent.com/matej/homebridge-nilan/master/resources/images/nilan-compact-p.png" height="200" alt="Nilan Compact P">
 
 ## Hardware Setup
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,7 @@ Configure `homebridge-nilan` on npm with this trusted publisher:
 | Allowed action | `npm publish` |
 
 This can be configured under the package's trusted-publisher settings on
-npmjs.com or with npm 11.5.1 or newer while authenticated with two-factor
+npmjs.com or with npm 11.15.0 or newer while authenticated with two-factor
 authentication:
 
 ```sh
@@ -35,15 +35,18 @@ revoke any obsolete npm automation tokens.
 
 ## Release process
 
-1. Update `version` in both `package.json` and `package-lock.json` in a pull
-   request, and document user-visible changes.
+1. Check `npm view homebridge-nilan version`, then update `version` in both
+   `package.json` and `package-lock.json` to a strictly newer version in a pull
+   request and document user-visible changes.
 2. Merge the pull request after all required checks pass.
 3. Create and publish a GitHub Release from `master` using the exact tag
    `v<package-version>`, for example `v2.0.0`.
 4. Monitor the **Release** workflow. It validates the tag and commit, runs the
    complete test suite, inspects the npm tarball, and publishes it with
    provenance.
-5. Confirm the new version on npm and install it in a test Homebridge instance.
+5. Confirm the new version on npm, review its distribution tags, and install it
+   in a test Homebridge instance. Remove obsolete distribution tags only after
+   the replacement release is verified.
 
 Stable GitHub Releases publish with the npm `latest` distribution tag. GitHub
 pre-releases publish with the `next` tag.

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "main": "dist/index.js",
   "files": [
     "config.schema.json",
-    "dist",
-    "resources"
+    "dist"
   ],
   "scripts": {
     "check": "npm run lint && npm run build && npm test",

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -3,7 +3,7 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
-const MAX_PACKAGE_SIZE = 5 * 1024 * 1024;
+const MAX_PACKAGE_SIZE = 512 * 1024;
 const REQUIRED_FILES = [
   'LICENSE',
   'README.md',
@@ -32,7 +32,9 @@ export function verifyPackageReport(report, packageJson) {
       `Packed identity ${packed.name}@${packed.version} does not match ${packageJson.name}@${packageJson.version}`,
     );
   }
-  if (typeof packed.filename !== 'string' || path.basename(packed.filename) !== packed.filename || !packed.filename.endsWith('.tgz')) {
+  if (typeof packed.filename !== 'string' ||
+    path.basename(packed.filename) !== packed.filename ||
+    !/^[A-Za-z0-9@._-]+\.tgz$/.test(packed.filename)) {
     throw new Error(`Unsafe or invalid package filename: ${packed.filename}`);
   }
   if (!Number.isFinite(packed.size) || packed.size <= 0 || packed.size > MAX_PACKAGE_SIZE) {

--- a/src/cts700Data.ts
+++ b/src/cts700Data.ts
@@ -135,11 +135,11 @@ export interface Settings {
 	systemWorkingMode: SystemWorkingMode;
     // Paused tells if operation is currently paused
 	paused: PauseOption;
-	// Fan speed of ventilation (20-100)
+	// User fan-speed register after decoding (0-100%; explicit writes are limited to 20-100%).
 	fanSpeed: number;
-	// Desired room temperature in C (5-40) times 10
+	// Desired room temperature after decoding (5-50°C).
 	roomTemperatureSetPoint: number;
-	// Desired DHW temperature in C (10-65) times 10
+	// Desired DHW temperature after decoding (10-65°C).
 	dhwTemperatureSetPoint: number;
 	// Ventilation mode indicates automatic or forced aur conditioning operation
 	ventilationMode: VentilationMode;
@@ -149,11 +149,11 @@ export interface Settings {
 
 // Readings from Nilan sensors
 export interface Readings {
-	// Room temperature in C times 10
+	// Room temperature after decoding in °C.
 	roomTemperature: number;
-	// Outdoor temperature in C times 10
+	// Outdoor temperature after decoding in °C.
 	outdoorTemperature: number;
-	// Panel temperature in C times 10
+	// Panel temperature after decoding in °C.
 	panelTemperature: number;
 	// Actual humidity of air (0-100%)
 	actualHumidity: number;
@@ -164,7 +164,7 @@ export interface Readings {
 	inletFilterElapsedDays: number | null;
 	outletFilterReplacementInterval: number | null;
 	outletFilterElapsedDays: number | null;
-	// DHW tank top temperature in C times 10
+	// DHW tank top temperature after decoding in °C.
 	dhwTankTopTemperature: number;
 	// Current device time.
 	currentDateTime: DateTime;
@@ -196,9 +196,9 @@ export interface WeekScheduleRecord {
 	hour: number;
 	// Minutes (0 ÷ 59)
 	minute: number;
-	// 50 ÷ 500 (5ºC ÷ 50ºC)
+	// Room target after decoding (5°C ÷ 50°C).
 	temperature: number;
-	// 100 ÷ 600 (10ºC ÷ 60ºC)
+	// DHW target after decoding (10°C ÷ 60°C).
 	dhwTemperature: number;
 	// Flag bitmask
 	flags: number;

--- a/test/verifyPackage.test.mjs
+++ b/test/verifyPackage.test.mjs
@@ -47,12 +47,17 @@ describe('verifyPackageReport', () => {
   });
 
   it('rejects an unexpectedly large package', () => {
-    expect(() => verifyPackageReport(createReport({ size: 5 * 1024 * 1024 + 1 }), packageJson))
+    expect(() => verifyPackageReport(createReport({ size: 512 * 1024 + 1 }), packageJson))
       .toThrow('must be between');
   });
 
   it('rejects an unsafe tarball filename', () => {
     expect(() => verifyPackageReport(createReport({ filename: '../package.tgz' }), packageJson))
+      .toThrow('Unsafe or invalid package filename');
+  });
+
+  it('rejects control characters and shell metacharacters in a tarball filename', () => {
+    expect(() => verifyPackageReport(createReport({ filename: 'package\n$(command).tgz' }), packageJson))
       .toThrow('Unsafe or invalid package filename');
   });
 });


### PR DESCRIPTION
## Summary

- keep Dependabot major upgrades in separate PRs while grouping compatible minor and patch updates
- fix the trusted-publishing npm version boundary and document the newer CLI required to manage trust
- require release versions to be newer than the npm registry version
- tighten tarball filename validation and reduce the package-size ceiling
- serve README images from the repository while excluding screenshots from npm installations
- correct decoded-unit and range comments in the CTS700 protocol types

The repository Actions policy now independently requires full commit-SHA pinning and permits only GitHub-owned actions; all current workflows comply.

## Validation

- `npm run check`: 62 tests pass
- real tarball inspected successfully
- packed size reduced from approximately 4.1 MB to 33 KB
- npm audit remains clean

No package was published and no hardware was contacted.
