### PR TITLE
Improve runtime failure visibility

### DIFF
--- a/src/compactPAccessory.ts
+++ b/src/compactPAccessory.ts
@@ -12,7 +12,7 @@ import {
 import type { NilanHomebridgePlatform } from './platform';
 
 type WriterParameter = boolean | number | PauseOption | VentilationMode;
-type ModbusFactory = (host: string, didConnect: () => void) => CTS700Modbus;
+type ModbusFactory = (host: string, didConnect: () => void, connectionFailed: (error: unknown) => void) => CTS700Modbus;
 const RESOLVER_CHECKPOINT_INTERVAL_MS = 5 * 60 * 1000;
 const RESOLVER_CONTEXT_KEY = 'targetResolverState';
 
@@ -40,12 +40,18 @@ export class CompactPPlatformAccessory {
   constructor(
     private readonly platform: NilanHomebridgePlatform,
     private readonly accessory: PlatformAccessory,
-    modbusFactory: ModbusFactory = (host, didConnect) => new CTS700Modbus(host, didConnect),
+    modbusFactory: ModbusFactory = (host, didConnect, connectionFailed) => new CTS700Modbus(host, didConnect, connectionFailed),
   ) {
 
-    this.cts700Modbus = modbusFactory(this.accessory.context.device.host, () => {
-      this.setUpAfterConnection();
-    }); 
+    this.cts700Modbus = modbusFactory(
+      this.accessory.context.device.host,
+      () => {
+        this.setUpAfterConnection();
+      },
+      (error) => {
+        this.platform.log.warn('Could not connect to the CTS700 controller.', error instanceof Error ? error.message : String(error));
+      },
+    );
 
     // Accessory information
     this.accessory.getService(platform.Service.AccessoryInformation)!

--- a/src/cts700Modbus.ts
+++ b/src/cts700Modbus.ts
@@ -40,6 +40,7 @@ export class CTS700Modbus {
   constructor(
       private readonly host: string,
       private readonly didConnect: () => void,
+      private readonly connectionFailed: (error: unknown) => void = () => undefined,
   ) {
     this.connect();
   }
@@ -63,6 +64,7 @@ export class CTS700Modbus {
         this.didConnect();    
       })
       .catch((e) => {
+        this.connectionFailed(e);
         this.checkError(e, true);
       });
   }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -57,6 +57,7 @@ export class NilanHomebridgePlatform implements DynamicPlatformPlugin {
   discoverDevices() {
     const devices = this.config.devices;
     if (!Array.isArray(devices)) {
+      this.log.warn(`No devices configured; cached accessories will remain inactive (count: ${this.accessories.length}).`);
       return;
     }
 

--- a/test/compactPAccessory.test.ts
+++ b/test/compactPAccessory.test.ts
@@ -158,6 +158,12 @@ async function invokeSet(service: FakeService, characteristic: unknown, value: C
   await vi.waitFor(() => expect(callback).toHaveBeenCalledWith(null));
 }
 
+async function invokeSetFailure(service: FakeService, characteristic: unknown, value: CharacteristicValue) {
+  const callback = vi.fn();
+  service.getCharacteristic(characteristic).setHandler!(value, callback);
+  await vi.waitFor(() => expect(callback).toHaveBeenCalledWith(expect.any(Error)));
+}
+
 beforeEach(() => {
   vi.useFakeTimers();
 });
@@ -272,6 +278,58 @@ describe('CompactPPlatformAccessory', () => {
     expect(services.get('compact-p-fan')!.updates).toContainEqual([Characteristic.RotationSpeed, 60]);
     expect(services.get('compact-p-temperature')!.updates).toContainEqual([Characteristic.TargetTemperature, 22]);
     expect(services.get('compact-p-dhw')!.updates).toContainEqual([Characteristic.TargetTemperature, 50]);
+  });
+
+  it('maps forced cooling writes and controller state to HomeKit', async () => {
+    const { Characteristic, modbus, services } = createHarness();
+    modbus.fetchSettings.mockResolvedValue({
+      ...await modbus.fetchSettings(),
+      operationMode: OperationMode.Cooling,
+      ventilationMode: VentilationMode.Cooling,
+    });
+    modbus.fetchSettings.mockClear();
+
+    await invokeSet(
+      services.get('compact-p-temperature')!,
+      Characteristic.TargetHeatingCoolingState,
+      Characteristic.TargetHeatingCoolingState.COOL,
+    );
+    await vi.advanceTimersByTimeAsync(10000);
+
+    expect(modbus.writeVentilationMode).toHaveBeenCalledWith(VentilationMode.Cooling);
+    expect(services.get('compact-p-temperature')!.updates).toContainEqual([
+      Characteristic.TargetHeatingCoolingState,
+      Characteristic.TargetHeatingCoolingState.COOL,
+    ]);
+    expect(services.get('compact-p-temperature')!.updates).toContainEqual([
+      Characteristic.CurrentHeatingCoolingState,
+      Characteristic.CurrentHeatingCoolingState.COOL,
+    ]);
+  });
+
+  it('does not record a temperature override when the controller write fails', async () => {
+    const { Characteristic, modbus, services } = createHarness(true);
+    modbus.fetchSettings.mockResolvedValue({
+      ...await modbus.fetchSettings(),
+      systemWorkingMode: SystemWorkingMode.Auto,
+    });
+    modbus.fetchSettings.mockClear();
+    modbus.fetchActiveWeekProgramForDateTime.mockResolvedValue({
+      dhwTemperature: 48,
+      fanSpeed: 40,
+      flags: 0,
+      hour: 3,
+      minute: 0,
+      temperature: 20,
+      weekDay: 5,
+    });
+    modbus.writeRoomTemperatureSetPoint.mockRejectedValueOnce(new Error('write failed'));
+
+    await vi.advanceTimersByTimeAsync(10000);
+    await invokeSetFailure(services.get('compact-p-temperature')!, Characteristic.TargetTemperature, 23);
+    await vi.advanceTimersByTimeAsync(10000);
+
+    expect(services.get('compact-p-temperature')!.updates.at(-1)).toEqual([Characteristic.TargetTemperature, 20]);
   });
 
   it('reports effective fan output after a write without retrying the user target', async () => {
@@ -476,6 +534,19 @@ describe('CompactPPlatformAccessory', () => {
     await vi.advanceTimersByTimeAsync(0);
     await vi.advanceTimersByTimeAsync(10000);
     expect(modbus.fetchReadings).toHaveBeenCalledTimes(2);
+  });
+
+  it('recovers on the next cycle after a polling failure', async () => {
+    const { Characteristic, modbus, platform, services } = createHarness();
+    modbus.fetchReadings.mockRejectedValueOnce(new Error('temporary read failure'));
+
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(platform.log.error).toHaveBeenCalledWith('Could not update readings and settings.', 'temporary read failure');
+
+    await vi.advanceTimersByTimeAsync(10000);
+
+    expect(modbus.fetchReadings).toHaveBeenCalledTimes(2);
+    expect(services.get('compact-p-temperature')!.updates).toContainEqual([Characteristic.CurrentTemperature, 21]);
   });
 
   it('cleans up polling and Modbus state on shutdown', async () => {

--- a/test/cts700Modbus.test.ts
+++ b/test/cts700Modbus.test.ts
@@ -110,6 +110,17 @@ describe('CTS700Modbus connection', () => {
     expect(client.connectTCP).toHaveBeenCalledOnce();
     vi.useRealTimers();
   });
+
+  it('reports connection failures before scheduling a retry', async () => {
+    const error = Object.assign(new Error('connection refused'), { code: 'ECONNREFUSED' });
+    const connectionFailed = vi.fn();
+    client.connectTCP.mockRejectedValueOnce(error);
+
+    const modbus = new CTS700Modbus('192.0.2.1', vi.fn(), connectionFailed);
+    await vi.waitFor(() => expect(connectionFailed).toHaveBeenCalledWith(error));
+
+    modbus.close();
+  });
 });
 
 describe('CTS700Modbus reads', () => {

--- a/test/cts700TargetResolver.test.ts
+++ b/test/cts700TargetResolver.test.ts
@@ -137,6 +137,47 @@ describe('CTS700TargetResolver', () => {
     )).toBe(false);
   });
 
+  it('rejects snapshots when controller time moves backwards or is not a real calendar date', () => {
+    const original = new CTS700TargetResolver();
+    original.resolveAutomaticTargets(userTargets, sundayNight);
+    original.markUserOverride('roomTemperature', 23);
+    const snapshot = original.createSnapshot(controllerTime);
+
+    expect(new CTS700TargetResolver().restoreSnapshot(
+      snapshot,
+      { ...controllerTime, minute: 4 },
+      sundayNight,
+      userTargets,
+    )).toBe(false);
+    expect(new CTS700TargetResolver().restoreSnapshot(
+      snapshot,
+      { ...controllerTime, day: 30, month: 2 },
+      sundayNight,
+      userTargets,
+    )).toBe(false);
+  });
+
+  it('restores a recent override across midnight when the active schedule record is unchanged', () => {
+    const beforeMidnight = { ...controllerTime, minute: 55 };
+    const afterMidnight: DateTime = {
+      ...controllerTime,
+      minute: 5,
+      hour: 0,
+      day: 17,
+      weekDay: 1,
+    };
+    const original = new CTS700TargetResolver();
+    original.resolveAutomaticTargets(userTargets, sundayNight);
+    original.markUserOverride('roomTemperature', 23);
+
+    expect(new CTS700TargetResolver().restoreSnapshot(
+      original.createSnapshot(beforeMidnight),
+      afterMidnight,
+      sundayNight,
+      userTargets,
+    )).toBe(true);
+  });
+
   it('does not create persisted state without an active override', () => {
     const resolver = new CTS700TargetResolver();
     resolver.resolveAutomaticTargets(userTargets, sundayNight);

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -26,7 +26,7 @@ class FakePlatformAccessory {
   ) {}
 }
 
-function createHarness(devices: unknown[]) {
+function createHarness(devices?: unknown[]) {
   const listeners = new Map<string, () => void>();
   const api = {
     hap: {
@@ -129,5 +129,18 @@ describe('NilanHomebridgePlatform discovery', () => {
 
     expect(handlers).toHaveLength(2);
     expect(handlers.every(handler => handler.shutdown.mock.calls.length === 1)).toBe(true);
+  });
+
+  it('warns when cached accessories cannot be activated without a device list', () => {
+    const { api, log, platform } = createHarness();
+    const cached = new FakePlatformAccessory('Cached', 'uuid:192.0.2.10');
+    cached.context.device = { host: '192.0.2.10' };
+    platform.configureAccessory(cached as unknown as PlatformAccessory);
+
+    platform.discoverDevices();
+
+    expect(log.warn).toHaveBeenCalledWith('No devices configured; cached accessories will remain inactive (count: 1).');
+    expect(api.unregisterPlatformAccessories).not.toHaveBeenCalled();
+    expect(MockAccessoryHandler).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- report initial and reconnect failures through the Homebridge logger
- warn when cached accessories cannot be activated because the device list is missing
- retain cached accessories rather than deleting them for malformed configuration
- expand behavioral coverage for poll recovery, forced cooling, failed target writes, controller-clock validation, and midnight recovery

## Validation

- `npm run check`: 69 tests pass
- coverage: 91.95% statements, 85.85% branches, 94.73% functions, 91.88% lines

No hardware writes or live controller access were performed.
