### PR TITLE
Prepare 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+## 2.0.0
+
+### Upgrade notes
+
+- Node.js 22.10 or newer in the Node 22 or Node 24 release lines is required.
+- Homebridge 1.8 and 2.x are supported.
+- Existing accessory UUIDs and HomeKit service identities are preserved.
+
+### Changed
+
+- Week schedules are now read without copying schedule values into user
+  registers. Room and hot-water overrides are tracked independently, and
+  recent validated overrides survive short Homebridge restarts.
+- Fan speed now reports the controller's effective inlet-fan output, including
+  automatic adjustments made for humidity, cooling, or system balancing.
+- Fan pause and hot-water pause updates are serialized so concurrent HomeKit
+  actions cannot overwrite each other in the shared controller register.
+- Filter maintenance is exposed using the controller's time-based inlet and
+  outlet filter counters. Invalid counters no longer interrupt unrelated
+  polling updates.
+- The TypeScript, lint, test, Homebridge, and Node.js toolchain has been
+  modernized. The expanded mocked test suite covers protocol conversions,
+  reconnects, schedules, overrides, pause behavior, and HomeKit mappings.
+
+### Added
+
+- Read-only CTS 700 diagnostic and settings-inventory commands for hardware
+  investigation without controller writes.
+- Automated GitHub Release publishing to npm using trusted publishing and
+  provenance.
+- CI on Node.js 22 and 24, dependency review, CodeQL analysis, Dependabot,
+  security policy, contribution guidance, and coding-agent instructions.
+
+### Fixed
+
+- Corrected signed register decoding, temperature limits and scaling, schedule
+  boundary handling, Modbus reconnect behavior, and failed-write state
+  tracking.
+- Improved warnings for connection failures and missing device configuration.
+- Repaired README images and replaced the unavailable CTS 700 register-manual
+  link with a preserved revision.
+- Reduced the published package by excluding development screenshots and other
+  repository-only assets.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-nilan",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-nilan",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "modbus-serial": "^8.0.25"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Nilan",
   "name": "homebridge-nilan",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Homebridge plugin for Nilan Compact P.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/matej/homebridge-nilan#readme",
@@ -18,6 +18,7 @@
   },
   "main": "dist/index.js",
   "files": [
+    "CHANGELOG.md",
     "config.schema.json",
     "dist"
   ],


### PR DESCRIPTION
## Summary
- bump the package and lockfile to 2.0.0
- add upgrade notes and a consolidated user-facing changelog
- include the changelog in the npm package

## Validation
- npm run check (69 tests)
- npm pack: 33,742-byte tarball, 33 entries

This is a major release because the supported Node.js baseline has moved to Node 22/24 and schedule/target reporting behavior has materially changed. Existing accessory UUIDs and HomeKit service identities remain unchanged.