### PR TITLE
Prepare 2.0.0 beta preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.0.0
+## 2.0.0-beta.1
 
 ### Upgrade notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-nilan",
-  "version": "2.0.0",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-nilan",
-      "version": "2.0.0",
+      "version": "2.0.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "modbus-serial": "^8.0.25"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Nilan",
   "name": "homebridge-nilan",
-  "version": "2.0.0",
+  "version": "2.0.0-beta.1",
   "description": "Homebridge plugin for Nilan Compact P.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/matej/homebridge-nilan#readme",


### PR DESCRIPTION
## Summary
- version the preview as 2.0.0-beta.1 so 2.0.0 remains available for the final release
- identify the matching changelog entry as the beta preview

## Validation
- npm run check (69 tests)

After this merges, the preview will be published as a GitHub pre-release and under npm's next distribution tag.