### PR TITLE
Constrain hot-water thermostat modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Constrained the hot-water thermostat to Off and Heat and reject unsupported
+  Cool or Auto requests from HomeKit clients.
+
 ## 2.0.0-beta.1
 
 ### Upgrade notes

--- a/src/compactPAccessory.ts
+++ b/src/compactPAccessory.ts
@@ -207,9 +207,15 @@ export class CompactPPlatformAccessory {
 
     const c = platform.Characteristic;
     dhwThermostatService.getCharacteristic(c.CurrentHeatingCoolingState).setProps({
+      minValue: c.CurrentHeatingCoolingState.OFF,
+      maxValue: c.CurrentHeatingCoolingState.HEAT,
+      minStep: 1,
       validValues: [c.CurrentHeatingCoolingState.OFF, c.CurrentHeatingCoolingState.HEAT],
     });
     dhwThermostatService.getCharacteristic(c.TargetHeatingCoolingState).setProps({
+      minValue: c.TargetHeatingCoolingState.OFF,
+      maxValue: c.TargetHeatingCoolingState.HEAT,
+      minStep: 1,
       validValues: [c.TargetHeatingCoolingState.OFF, c.TargetHeatingCoolingState.HEAT],
     });
     dhwThermostatService.updateCharacteristic(c.TemperatureDisplayUnits, c.TemperatureDisplayUnits.CELSIUS);
@@ -232,6 +238,10 @@ export class CompactPPlatformAccessory {
 
     dhwThermostatService.getCharacteristic(c.TargetHeatingCoolingState)
       .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+        if (value !== c.TargetHeatingCoolingState.OFF && value !== c.TargetHeatingCoolingState.HEAT) {
+          callback(new Error('Hot water supports only Off and Heat modes.'));
+          return;
+        }
         const paused = value === c.TargetHeatingCoolingState.OFF;
         this.handleWrite(next => this.cts700Modbus.writeDHWPaused(next), paused, 'DHW pause', callback);
       });

--- a/test/compactPAccessory.test.ts
+++ b/test/compactPAccessory.test.ts
@@ -196,13 +196,35 @@ describe('CompactPPlatformAccessory', () => {
     expect(modbus.writeVentilationMode).toHaveBeenCalledWith(VentilationMode.Heating);
   });
 
-  it('uses the controller-supported DHW temperature range', () => {
+  it('uses the controller-supported DHW temperature and mode ranges', () => {
     const { Characteristic, services } = createHarness();
 
     expect(services.get('compact-p-dhw')!.getCharacteristic(Characteristic.TargetTemperature).props).toMatchObject({
       minValue: 10,
       maxValue: 65,
     });
+    expect(services.get('compact-p-dhw')!.getCharacteristic(Characteristic.CurrentHeatingCoolingState).props).toMatchObject({
+      minValue: Characteristic.CurrentHeatingCoolingState.OFF,
+      maxValue: Characteristic.CurrentHeatingCoolingState.HEAT,
+      minStep: 1,
+      validValues: [Characteristic.CurrentHeatingCoolingState.OFF, Characteristic.CurrentHeatingCoolingState.HEAT],
+    });
+    expect(services.get('compact-p-dhw')!.getCharacteristic(Characteristic.TargetHeatingCoolingState).props).toMatchObject({
+      minValue: Characteristic.TargetHeatingCoolingState.OFF,
+      maxValue: Characteristic.TargetHeatingCoolingState.HEAT,
+      minStep: 1,
+      validValues: [Characteristic.TargetHeatingCoolingState.OFF, Characteristic.TargetHeatingCoolingState.HEAT],
+    });
+  });
+
+  it('rejects unsupported DHW cooling and automatic modes', async () => {
+    const { Characteristic, modbus, services } = createHarness();
+    const dhw = services.get('compact-p-dhw')!;
+
+    await invokeSetFailure(dhw, Characteristic.TargetHeatingCoolingState, Characteristic.TargetHeatingCoolingState.COOL);
+    await invokeSetFailure(dhw, Characteristic.TargetHeatingCoolingState, Characteristic.TargetHeatingCoolingState.AUTO);
+
+    expect(modbus.writeDHWPaused).not.toHaveBeenCalled();
   });
 
   it('supports the full effective fan-output range', () => {


### PR DESCRIPTION
## Summary
- constrain the hot-water current and target mode metadata to Off and Heat
- reject Cool and Auto writes instead of treating every non-Off mode as hot water enabled
- document and test the corrected HomeKit contract

## Validation
- npm run check (70 tests)

Some HomeKit clients may continue drawing their generic four-mode thermostat control, but unsupported values are no longer advertised or accepted.