### PR TITLE
Prepare 2.0.0 beta 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.0.0-beta.2
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-nilan",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-nilan",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "modbus-serial": "^8.0.25"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Nilan",
   "name": "homebridge-nilan",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Homebridge plugin for Nilan Compact P.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/matej/homebridge-nilan#readme",


### PR DESCRIPTION
## Summary
- bump the preview version to 2.0.0-beta.2
- publish the hot-water Off/Heat mode correction for testing

## Validation
- npm run check (70 tests)

After merge this will be published as a GitHub pre-release and under npm's next tag.